### PR TITLE
Add ArXiv paper scraper with GitHub Pages

### DIFF
--- a/arxiv-scraper/.github/workflows/scrape-papers.yml
+++ b/arxiv-scraper/.github/workflows/scrape-papers.yml
@@ -1,0 +1,35 @@
+name: Scrape ArXiv Papers
+
+on:
+  schedule:
+    # Run daily at 9 AM UTC
+    - cron: '0 9 * * *'
+  workflow_dispatch:  # Allow manual triggering
+
+permissions:
+  contents: write
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run scraper
+        run: |
+          cd arxiv-scraper
+          python scripts/scrape_arxiv.py
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+          git add arxiv-scraper/data/papers.json
+          git diff --quiet && git diff --staged --quiet || (git commit -m "Update arxiv papers - $(date +'%Y-%m-%d')" && git push)

--- a/arxiv-scraper/README.md
+++ b/arxiv-scraper/README.md
@@ -1,0 +1,154 @@
+# ArXiv Paper Scraper
+
+A daily curated feed of interesting AI and Cybersecurity research papers from arXiv.org, automatically updated via GitHub Actions and displayed on GitHub Pages.
+
+## Features
+
+- 🤖 **Automated Daily Updates**: GitHub Action runs daily to scrape new papers
+- 📊 **Smart Selection**: Intelligently selects one interesting paper per day based on keywords and relevance
+- 🎨 **Clean Interface**: Simple, responsive HTML page (no React, just vanilla JS)
+- 📚 **Research Focus**: Covers AI (Machine Learning, Computer Vision, NLP) and Cybersecurity topics
+- 📱 **Mobile Friendly**: Responsive design works on all devices
+
+## How It Works
+
+1. **GitHub Action** (`scrape-papers.yml`) runs daily at 9 AM UTC
+2. **Python Script** (`scrape_arxiv.py`) fetches papers from arXiv API
+3. Papers are filtered by categories: AI (cs.AI, cs.LG, cs.CL, cs.CV) and Security (cs.CR)
+4. One interesting paper is selected based on keywords and scored
+5. Selected paper is saved to `data/papers.json`
+6. GitHub Pages displays the papers from the JSON file
+
+## Setting Up GitHub Pages
+
+### Step 1: Enable GitHub Pages
+
+1. Go to your repository on GitHub
+2. Click on **Settings** (top right)
+3. Scroll down to **Pages** (left sidebar)
+4. Under **Source**, select:
+   - **Source**: Deploy from a branch
+   - **Branch**: Select your main branch (e.g., `main` or `master`)
+   - **Folder**: Select `/arxiv-scraper` (or `/` if this is the root)
+5. Click **Save**
+
+### Step 2: Configure GitHub Pages Path
+
+If `arxiv-scraper` is in a subdirectory:
+
+1. After enabling Pages, note your site URL (e.g., `https://username.github.io/repo-name/`)
+2. Your site will be accessible at: `https://username.github.io/repo-name/arxiv-scraper/`
+
+### Step 3: Enable GitHub Actions
+
+1. Go to **Settings** → **Actions** → **General**
+2. Under **Workflow permissions**, select:
+   - ✅ **Read and write permissions**
+   - ✅ **Allow GitHub Actions to create and approve pull requests**
+3. Click **Save**
+
+### Step 4: Run Initial Scrape
+
+1. Go to **Actions** tab
+2. Click on **Scrape ArXiv Papers** workflow
+3. Click **Run workflow** button
+4. Wait for the workflow to complete
+5. Check that `data/papers.json` has been updated
+
+### Step 5: Visit Your Site
+
+After a few minutes, visit your GitHub Pages URL:
+- If in subdirectory: `https://username.github.io/repo-name/arxiv-scraper/`
+- If in root: `https://username.github.io/repo-name/`
+
+## Manual Testing
+
+You can run the scraper locally:
+
+```bash
+cd arxiv-scraper
+python scripts/scrape_arxiv.py
+```
+
+Then open `index.html` in your browser to preview the page.
+
+## Customization
+
+### Change Update Frequency
+
+Edit `.github/workflows/scrape-papers.yml`:
+
+```yaml
+schedule:
+  - cron: '0 9 * * *'  # Change this cron expression
+```
+
+Examples:
+- `'0 9 * * *'` - Daily at 9 AM UTC
+- `'0 */6 * * *'` - Every 6 hours
+- `'0 9 * * 1'` - Every Monday at 9 AM UTC
+
+### Modify Search Categories
+
+Edit `scripts/scrape_arxiv.py` and change the `SEARCH_QUERIES` list:
+
+```python
+SEARCH_QUERIES = [
+    "cat:cs.AI",  # Artificial Intelligence
+    "cat:cs.CR",  # Cryptography and Security
+    # Add more categories as needed
+]
+```
+
+### Adjust Paper Selection
+
+Modify the `interesting_keywords` list in `select_interesting_paper()` function to change how papers are scored and selected.
+
+## File Structure
+
+```
+arxiv-scraper/
+├── .github/
+│   └── workflows/
+│       └── scrape-papers.yml    # GitHub Action workflow
+├── data/
+│   └── papers.json              # Stored papers data
+├── scripts/
+│   └── scrape_arxiv.py          # Scraper script
+├── index.html                   # Main page
+├── styles.css                   # Styling
+└── README.md                    # This file
+```
+
+## Troubleshooting
+
+### Papers not updating?
+
+1. Check the **Actions** tab for failed workflow runs
+2. Verify **Workflow permissions** are set to "Read and write"
+3. Check that the scraper script has no errors
+
+### Page not displaying?
+
+1. Ensure GitHub Pages is enabled and configured correctly
+2. Check browser console for JavaScript errors
+3. Verify `data/papers.json` exists and contains valid JSON
+
+### Want to test locally?
+
+Run the scraper and use a local server:
+
+```bash
+python scripts/scrape_arxiv.py
+python -m http.server 8000
+```
+
+Then visit `http://localhost:8000`
+
+## Credits
+
+Papers sourced from [arXiv.org](https://arxiv.org) using their public API.
+
+## License
+
+This project is open source and available for educational purposes.

--- a/arxiv-scraper/data/papers.json
+++ b/arxiv-scraper/data/papers.json
@@ -1,0 +1,55 @@
+[
+  {
+    "id": "2312.12345",
+    "title": "Large Language Models for Automated Vulnerability Detection in Smart Contracts",
+    "summary": "We present a novel approach for detecting security vulnerabilities in smart contracts using large language models. Our method achieves state-of-the-art performance on benchmark datasets, demonstrating the potential of LLMs in automated security analysis. We evaluate our approach on over 10,000 smart contracts and show significant improvements in both precision and recall compared to existing static analysis tools.",
+    "published": "2024-12-15T10:30:00Z",
+    "link": "http://arxiv.org/abs/2312.12345",
+    "authors": [
+      "Jane Smith",
+      "John Doe",
+      "Alice Johnson"
+    ],
+    "categories": [
+      "cs.CR",
+      "cs.AI",
+      "cs.SE"
+    ],
+    "selected_date": "2024-12-28"
+  },
+  {
+    "id": "2312.54321",
+    "title": "Adversarial Robustness in Vision Transformers: A Comprehensive Survey",
+    "summary": "This survey provides a comprehensive overview of adversarial robustness techniques for vision transformers. We categorize existing defense mechanisms, analyze their effectiveness, and identify key challenges and future research directions. Our analysis covers both training-time and inference-time defenses, providing insights into the trade-offs between robustness and accuracy.",
+    "published": "2024-12-14T14:20:00Z",
+    "link": "http://arxiv.org/abs/2312.54321",
+    "authors": [
+      "Robert Chen",
+      "Maria Garcia"
+    ],
+    "categories": [
+      "cs.CV",
+      "cs.LG",
+      "cs.CR"
+    ],
+    "selected_date": "2024-12-27"
+  },
+  {
+    "id": "2312.98765",
+    "title": "Privacy-Preserving Federated Learning with Differential Privacy Guarantees",
+    "summary": "We propose a new framework for privacy-preserving federated learning that provides formal differential privacy guarantees while maintaining model utility. Our approach combines secure aggregation with adaptive noise injection, achieving better privacy-utility trade-offs than existing methods. Experiments on multiple datasets demonstrate the effectiveness of our approach in real-world scenarios.",
+    "published": "2024-12-13T09:15:00Z",
+    "link": "http://arxiv.org/abs/2312.98765",
+    "authors": [
+      "David Lee",
+      "Sarah Williams",
+      "Michael Brown",
+      "Emma Davis"
+    ],
+    "categories": [
+      "cs.CR",
+      "cs.LG"
+    ],
+    "selected_date": "2024-12-26"
+  }
+]

--- a/arxiv-scraper/index.html
+++ b/arxiv-scraper/index.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Daily ArXiv Papers - AI & Cybersecurity</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>📚 Daily ArXiv Papers</h1>
+            <p class="subtitle">Curated AI and Cybersecurity Research - One Paper Per Day</p>
+        </header>
+
+        <main>
+            <div id="loading" class="loading">
+                <p>Loading papers...</p>
+            </div>
+
+            <div id="papers-container" class="papers-container"></div>
+
+            <div id="error" class="error" style="display: none;">
+                <p>Unable to load papers. Please try again later.</p>
+            </div>
+        </main>
+
+        <footer>
+            <p>Papers are automatically curated daily from <a href="https://arxiv.org" target="_blank">arxiv.org</a></p>
+            <p>Last updated: <span id="last-updated">-</span></p>
+        </footer>
+    </div>
+
+    <script>
+        async function loadPapers() {
+            const loadingEl = document.getElementById('loading');
+            const errorEl = document.getElementById('error');
+            const containerEl = document.getElementById('papers-container');
+            const lastUpdatedEl = document.getElementById('last-updated');
+
+            try {
+                const response = await fetch('data/papers.json');
+
+                if (!response.ok) {
+                    throw new Error('Failed to load papers');
+                }
+
+                const papers = await response.json();
+
+                loadingEl.style.display = 'none';
+
+                if (!papers || papers.length === 0) {
+                    errorEl.style.display = 'block';
+                    errorEl.querySelector('p').textContent = 'No papers available yet.';
+                    return;
+                }
+
+                // Update last updated date
+                if (papers[0].selected_date) {
+                    lastUpdatedEl.textContent = papers[0].selected_date;
+                }
+
+                // Display papers
+                papers.forEach(paper => {
+                    const paperEl = createPaperElement(paper);
+                    containerEl.appendChild(paperEl);
+                });
+
+            } catch (error) {
+                console.error('Error loading papers:', error);
+                loadingEl.style.display = 'none';
+                errorEl.style.display = 'block';
+            }
+        }
+
+        function createPaperElement(paper) {
+            const article = document.createElement('article');
+            article.className = 'paper-card';
+
+            const dateEl = document.createElement('div');
+            dateEl.className = 'paper-date';
+            dateEl.textContent = paper.selected_date || 'Unknown Date';
+
+            const titleEl = document.createElement('h2');
+            titleEl.className = 'paper-title';
+            const titleLink = document.createElement('a');
+            titleLink.href = paper.link;
+            titleLink.target = '_blank';
+            titleLink.textContent = paper.title;
+            titleEl.appendChild(titleLink);
+
+            const authorsEl = document.createElement('div');
+            authorsEl.className = 'paper-authors';
+            authorsEl.textContent = paper.authors.join(', ');
+
+            const categoriesEl = document.createElement('div');
+            categoriesEl.className = 'paper-categories';
+            paper.categories.forEach(cat => {
+                const badge = document.createElement('span');
+                badge.className = 'category-badge';
+                badge.textContent = cat;
+                categoriesEl.appendChild(badge);
+            });
+
+            const summaryEl = document.createElement('div');
+            summaryEl.className = 'paper-summary';
+            summaryEl.textContent = paper.summary;
+
+            const linkEl = document.createElement('div');
+            linkEl.className = 'paper-link';
+            const readMoreLink = document.createElement('a');
+            readMoreLink.href = paper.link;
+            readMoreLink.target = '_blank';
+            readMoreLink.className = 'read-more';
+            readMoreLink.textContent = 'Read on ArXiv →';
+            linkEl.appendChild(readMoreLink);
+
+            article.appendChild(dateEl);
+            article.appendChild(titleEl);
+            article.appendChild(authorsEl);
+            article.appendChild(categoriesEl);
+            article.appendChild(summaryEl);
+            article.appendChild(linkEl);
+
+            return article;
+        }
+
+        // Load papers when page loads
+        document.addEventListener('DOMContentLoaded', loadPapers);
+    </script>
+</body>
+</html>

--- a/arxiv-scraper/scripts/scrape_arxiv.py
+++ b/arxiv-scraper/scripts/scrape_arxiv.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+Scrape arxiv.org for AI and cybersecurity related papers.
+Selects one interesting paper per day and stores it.
+"""
+
+import json
+import urllib.request
+import urllib.parse
+import xml.etree.ElementTree as ET
+from datetime import datetime, timedelta
+import os
+import random
+import time
+
+# ArXiv API base URL
+ARXIV_API = "http://export.arxiv.org/api/query?"
+
+# Search queries for AI and cybersecurity papers
+SEARCH_QUERIES = [
+    "cat:cs.AI OR cat:cs.LG OR cat:cs.CL OR cat:cs.CV",  # AI categories
+    "cat:cs.CR",  # Cryptography and Security
+    "all:cybersecurity OR all:adversarial OR all:security",
+]
+
+def fetch_arxiv_papers(query, max_results=20):
+    """Fetch papers from arxiv API."""
+    params = {
+        'search_query': query,
+        'start': 0,
+        'max_results': max_results,
+        'sortBy': 'submittedDate',
+        'sortOrder': 'descending'
+    }
+
+    url = ARXIV_API + urllib.parse.urlencode(params)
+
+    try:
+        # Add User-Agent header as required by arXiv API
+        req = urllib.request.Request(url)
+        req.add_header('User-Agent', 'Mozilla/5.0 (compatible; ArXivBot/1.0; +https://github.com)')
+
+        with urllib.request.urlopen(req) as response:
+            return response.read()
+    except Exception as e:
+        print(f"Error fetching papers: {e}")
+        return None
+
+def parse_arxiv_response(xml_data):
+    """Parse XML response from arxiv API."""
+    if not xml_data:
+        return []
+
+    # Parse XML
+    root = ET.fromstring(xml_data)
+
+    # Namespace for arxiv API
+    ns = {
+        'atom': 'http://www.w3.org/2005/Atom',
+        'arxiv': 'http://arxiv.org/schemas/atom'
+    }
+
+    papers = []
+
+    for entry in root.findall('atom:entry', ns):
+        paper = {}
+
+        # Extract paper details
+        paper['id'] = entry.find('atom:id', ns).text.split('/abs/')[-1]
+        paper['title'] = entry.find('atom:title', ns).text.strip().replace('\n', ' ')
+        paper['summary'] = entry.find('atom:summary', ns).text.strip().replace('\n', ' ')
+        paper['published'] = entry.find('atom:published', ns).text
+        paper['link'] = entry.find('atom:id', ns).text
+
+        # Authors
+        authors = []
+        for author in entry.findall('atom:author', ns):
+            name = author.find('atom:name', ns)
+            if name is not None:
+                authors.append(name.text)
+        paper['authors'] = authors
+
+        # Categories
+        categories = []
+        for category in entry.findall('atom:category', ns):
+            term = category.get('term')
+            if term:
+                categories.append(term)
+        paper['categories'] = categories
+
+        papers.append(paper)
+
+    return papers
+
+def select_interesting_paper(papers):
+    """Select one interesting paper from the list."""
+    if not papers:
+        return None
+
+    # Score papers based on interesting keywords in title/abstract
+    interesting_keywords = [
+        'novel', 'breakthrough', 'state-of-the-art', 'sota', 'survey',
+        'benchmark', 'dataset', 'transformer', 'neural', 'deep learning',
+        'vulnerability', 'attack', 'defense', 'privacy', 'encryption',
+        'adversarial', 'robust', 'secure', 'threat', 'malware'
+    ]
+
+    scored_papers = []
+    for paper in papers:
+        score = 0
+        text = (paper['title'] + ' ' + paper['summary']).lower()
+
+        for keyword in interesting_keywords:
+            if keyword in text:
+                score += 1
+
+        # Prefer papers with more authors (often more comprehensive)
+        score += min(len(paper['authors']), 5) * 0.1
+
+        scored_papers.append((score, paper))
+
+    # Sort by score and return top paper
+    scored_papers.sort(reverse=True, key=lambda x: x[0])
+
+    # Return the top paper, or a random one from top 5 if we have that many
+    if len(scored_papers) >= 5:
+        return random.choice([p[1] for p in scored_papers[:5]])
+    elif scored_papers:
+        return scored_papers[0][1]
+
+    return None
+
+def load_existing_papers(filepath):
+    """Load existing papers from JSON file."""
+    if os.path.exists(filepath):
+        try:
+            with open(filepath, 'r') as f:
+                return json.load(f)
+        except:
+            return []
+    return []
+
+def save_papers(papers, filepath):
+    """Save papers to JSON file."""
+    with open(filepath, 'w') as f:
+        json.dump(papers, f, indent=2)
+
+def main():
+    """Main function to scrape and store papers."""
+    print("Fetching papers from arxiv.org...")
+
+    all_papers = []
+
+    # Fetch papers for each query
+    for i, query in enumerate(SEARCH_QUERIES):
+        print(f"Searching: {query}")
+        xml_data = fetch_arxiv_papers(query, max_results=20)
+        papers = parse_arxiv_response(xml_data)
+        all_papers.extend(papers)
+
+        # Rate limiting: wait 3 seconds between requests (arXiv recommendation)
+        if i < len(SEARCH_QUERIES) - 1:
+            time.sleep(3)
+
+    # Remove duplicates by paper ID
+    seen_ids = set()
+    unique_papers = []
+    for paper in all_papers:
+        if paper['id'] not in seen_ids:
+            seen_ids.add(paper['id'])
+            unique_papers.append(paper)
+
+    print(f"Found {len(unique_papers)} unique papers")
+
+    # Select one interesting paper
+    selected_paper = select_interesting_paper(unique_papers)
+
+    if not selected_paper:
+        print("No papers found")
+        return
+
+    print(f"Selected paper: {selected_paper['title']}")
+
+    # Add selection date
+    selected_paper['selected_date'] = datetime.now().strftime('%Y-%m-%d')
+
+    # Load existing papers
+    data_dir = os.path.join(os.path.dirname(__file__), '..', 'data')
+    os.makedirs(data_dir, exist_ok=True)
+    filepath = os.path.join(data_dir, 'papers.json')
+
+    existing_papers = load_existing_papers(filepath)
+
+    # Check if we already have a paper for today
+    today = datetime.now().strftime('%Y-%m-%d')
+    has_today = any(p.get('selected_date') == today for p in existing_papers)
+
+    if not has_today:
+        # Add new paper to the beginning of the list
+        existing_papers.insert(0, selected_paper)
+
+        # Keep only last 30 days
+        existing_papers = existing_papers[:30]
+
+        # Save updated papers
+        save_papers(existing_papers, filepath)
+        print(f"Saved paper to {filepath}")
+    else:
+        print("Already have a paper for today")
+
+if __name__ == '__main__':
+    main()

--- a/arxiv-scraper/styles.css
+++ b/arxiv-scraper/styles.css
@@ -1,0 +1,217 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+:root {
+    --primary-color: #2c3e50;
+    --secondary-color: #3498db;
+    --accent-color: #e74c3c;
+    --bg-color: #f5f7fa;
+    --card-bg: #ffffff;
+    --text-color: #333333;
+    --text-muted: #7f8c8d;
+    --border-color: #e1e8ed;
+    --shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    --shadow-hover: 0 4px 16px rgba(0, 0, 0, 0.15);
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+        'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+        sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    line-height: 1.6;
+}
+
+.container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+header {
+    text-align: center;
+    padding: 40px 20px;
+    margin-bottom: 30px;
+}
+
+h1 {
+    font-size: 2.5rem;
+    color: var(--primary-color);
+    margin-bottom: 10px;
+    font-weight: 700;
+}
+
+.subtitle {
+    font-size: 1.1rem;
+    color: var(--text-muted);
+    font-weight: 400;
+}
+
+.loading,
+.error {
+    text-align: center;
+    padding: 40px;
+    font-size: 1.1rem;
+    color: var(--text-muted);
+}
+
+.error {
+    color: var(--accent-color);
+}
+
+.papers-container {
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
+    margin-bottom: 40px;
+}
+
+.paper-card {
+    background: var(--card-bg);
+    border-radius: 12px;
+    padding: 30px;
+    box-shadow: var(--shadow);
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.paper-card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-hover);
+}
+
+.paper-date {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    font-weight: 600;
+    margin-bottom: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.paper-title {
+    font-size: 1.5rem;
+    margin-bottom: 12px;
+    line-height: 1.3;
+}
+
+.paper-title a {
+    color: var(--primary-color);
+    text-decoration: none;
+    transition: color 0.2s;
+}
+
+.paper-title a:hover {
+    color: var(--secondary-color);
+}
+
+.paper-authors {
+    font-size: 0.95rem;
+    color: var(--text-muted);
+    margin-bottom: 12px;
+    font-style: italic;
+}
+
+.paper-categories {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+.category-badge {
+    display: inline-block;
+    background: var(--secondary-color);
+    color: white;
+    padding: 4px 12px;
+    border-radius: 16px;
+    font-size: 0.8rem;
+    font-weight: 500;
+}
+
+.paper-summary {
+    font-size: 1rem;
+    line-height: 1.7;
+    color: var(--text-color);
+    margin-bottom: 20px;
+    text-align: justify;
+}
+
+.paper-link {
+    text-align: right;
+}
+
+.read-more {
+    display: inline-block;
+    color: var(--secondary-color);
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 1rem;
+    transition: color 0.2s;
+}
+
+.read-more:hover {
+    color: var(--primary-color);
+}
+
+footer {
+    text-align: center;
+    padding: 30px 20px;
+    border-top: 1px solid var(--border-color);
+    margin-top: 40px;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+footer p {
+    margin-bottom: 8px;
+}
+
+footer a {
+    color: var(--secondary-color);
+    text-decoration: none;
+}
+
+footer a:hover {
+    text-decoration: underline;
+}
+
+#last-updated {
+    font-weight: 600;
+    color: var(--text-color);
+}
+
+@media (max-width: 768px) {
+    .container {
+        padding: 10px;
+    }
+
+    header {
+        padding: 20px 10px;
+    }
+
+    h1 {
+        font-size: 2rem;
+    }
+
+    .subtitle {
+        font-size: 1rem;
+    }
+
+    .paper-card {
+        padding: 20px;
+    }
+
+    .paper-title {
+        font-size: 1.3rem;
+    }
+
+    .paper-summary {
+        text-align: left;
+    }
+}


### PR DESCRIPTION
- Created daily scraper for AI and cybersecurity papers from arxiv.org
- Implements GitHub Action to run scraper daily at 9 AM UTC
- Simple HTML/CSS page to display curated papers (no React)
- Intelligent paper selection based on keywords and relevance
- Includes sample data and comprehensive setup documentation