### PR TITLE
Add git pull rebase and retry logic to fact generation workflow

### DIFF
--- a/.github/workflows/generate-science-facts.yml
+++ b/.github/workflows/generate-science-facts.yml
@@ -53,7 +53,24 @@ jobs:
 
           git add weird-science-fact/data/facts.json
           git commit -m "Update science facts cache - $(date +'%Y-%m-%d')"
-          git push
+
+          # Pull and rebase to handle any concurrent changes
+          git pull --rebase origin main || git pull --rebase origin master
+
+          # Push with retry logic
+          for i in 1 2 3; do
+            if git push; then
+              echo "✅ Successfully pushed changes"
+              exit 0
+            else
+              echo "⚠️  Push failed, attempt $i/3. Retrying..."
+              git pull --rebase origin main || git pull --rebase origin master
+              sleep 2
+            fi
+          done
+
+          echo "❌ Failed to push after 3 attempts"
+          exit 1
 
       - name: Summary
         run: |


### PR DESCRIPTION
Fixes issue where workflow fails to push if main branch was updated while the workflow was running (e.g., PR merged during generation).

Changes:
- Pull and rebase before pushing
- Retry push up to 3 times with rebase
- Clear error messages for each attempt
- Prevents losing generated facts due to concurrent updates

This handles the race condition when:
1. Workflow starts generating facts
2. User merges PR to main
3. Workflow tries to push (now fails)
4. NOW: Auto-rebases and retries ✅