### PR TITLE
Add Seashore Cottage Finder summer availability planner

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -19,6 +19,7 @@ on:
       - 'ai-honeypot-generator/**'
       - 'wasm-testbed/**'
       - 'cybersecurity-job-analyzer/**'
+      - 'seashore-cottage-finder/**'
       - 'about/**'
       - '.github/workflows/deploy-pages.yml'
   pull_request:
@@ -35,6 +36,7 @@ on:
       - 'ai-honeypot-generator/**'
       - 'wasm-testbed/**'
       - 'cybersecurity-job-analyzer/**'
+      - 'seashore-cottage-finder/**'
       - 'about/**'
   # Auto-deploy after data-generating workflows complete
   workflow_run:
@@ -135,6 +137,9 @@ jobs:
           mkdir -p _site/cybersecurity-job-analyzer
           cp -r cybersecurity-job-analyzer/index.html cybersecurity-job-analyzer/styles.css cybersecurity-job-analyzer/script.js _site/cybersecurity-job-analyzer/
           cp -r cybersecurity-job-analyzer/data _site/cybersecurity-job-analyzer/data 2>/dev/null || mkdir -p _site/cybersecurity-job-analyzer/data
+
+          # Copy seashore-cottage-finder to /seashore-cottage-finder subdirectory
+          cp -r seashore-cottage-finder _site/seashore-cottage-finder
 
           # Copy about to /about subdirectory
           cp -r about _site/about
@@ -242,6 +247,10 @@ jobs:
                       <a href="/friendly-enigma/wasm-testbed/" class="project-link">
                           <div class="project-title">🚀 WebAssembly Performance Lab</div>
                           <div class="project-desc">Interactive testbed for exploring WebAssembly with performance benchmarks</div>
+                      </a>
+                      <a href="/friendly-enigma/seashore-cottage-finder/" class="project-link">
+                          <div class="project-title">🏖️ Seashore Cottage Finder</div>
+                          <div class="project-desc">Scan a whole summer for open cottage dates at Sun Retreats Seashore instead of checking one date at a time</div>
                       </a>
                   </div>
               </div>

--- a/GITHUB_PAGES.md
+++ b/GITHUB_PAGES.md
@@ -12,6 +12,7 @@ This repository hosts multiple projects on GitHub Pages:
 - **Mermaid Diagrams** (`/mermaid-diagrams/`) - Create and visualize diagrams using Mermaid syntax
 - **Browser Vulnerability Scanner** (`/browser-vulnerability-scanner/`) - Detect security vulnerabilities in your browser and OS based on version
 - **AI Honeypot Generator** (`/ai-honeypot-generator/`) - Security research honeypots based on recent CVEs
+- **Seashore Cottage Finder** (`/seashore-cottage-finder/`) - Scan a whole summer for open cottage dates at Sun Retreats Seashore
 
 ## How It Works
 

--- a/seashore-cottage-finder/README.md
+++ b/seashore-cottage-finder/README.md
@@ -1,55 +1,69 @@
 # 🏖️ Seashore Cottage Finder
 
-A tiny, no-backend web tool for finding an open **Premium Cottage (2 Bedroom)**
+Automatically scan a whole summer for an open **Premium Cottage (2 Bedroom)**
 at [Sun Retreats Seashore](https://www.sunoutdoors.com/new-jersey/sun-retreats-seashore)
-across a whole summer — without clicking through hundreds of date combinations.
+— the machine does the date-by-date checking instead of you.
 
-## The insight
+## Why it works the way it does
 
-Availability is **per night**, not per stay window. The resort's booking
-calendar greys out nights that are already taken — a whole month at a glance.
-So instead of checking every possible check-in/check-out combination, you only
-need to know which individual nights are booked. From that, *every* open stay
-window can be computed.
+The obvious idea — "just call the booking API for every date" — doesn't work
+from a normal web page or a server. The site sits behind **Akamai bot
+protection**: any request that isn't a real browser with a valid session is
+rejected with `403 Access Denied`. A third-party page also can't reach it
+because of cross-origin (CORS) rules.
 
-## How it works
+There's exactly one place the call *does* work: **inside your own browser, on
+the booking site itself.** There, requests are same-origin and carry your real
+session cookies, so they pass Akamai and hit the same availability API the page
+already uses.
 
-1. **Trip preferences** — set your summer range, the stay lengths you'd accept
-   (2/3/4/7 nights), guests, and whether you only want weekend check-ins.
-2. **Teach it your booking link** *(optional)* — paste one booking URL that
-   already has dates in it, so the generated "Book ↗" links land on the exact
-   dates.
-3. **Mark the booked nights** — open the resort calendar (a link is provided per
-   month), and click the greyed-out nights here to mark them **Booked**. Then
-   hit *"Mark the rest as free."* That's roughly a dozen clicks for a summer.
-4. **Your open stays** — the tool instantly lists every stay that fits your
-   trip length and touches only free nights, each with a one-click booking
-   link. Copy or print the list.
+So the tool ships a small script (`auto-check.js`) that runs there. It:
 
-Nights cycle **Unknown → Free → Booked → Unknown** on click. Stays touching a
-booked night are dropped automatically; stays with still-unchecked nights show
-as "🤔 Check" if you enable that view.
+1. Quietly watches the site's network calls.
+2. Waits for you to run **one** normal availability search (so it learns the
+   exact request shape and how dates are encoded).
+3. Replays that request across every date window in your summer range, with a
+   polite delay, and lists which ones have the cottage open.
 
-Everything persists in `localStorage`, so you can come back later.
+## How to use it
 
-## Why it doesn't read availability automatically
+1. On the **Cottage Finder page** (`index.html`), set your trip preferences:
+   date range, stay lengths, check-in day, and a "unit keyword" that identifies
+   the cottage (default `Premium Cottage`).
+2. Open the booking site, then load the checker onto it — either by dragging
+   the generated **bookmarklet** to your bookmarks bar and clicking it on the
+   page, or by pasting the generated script into the browser **DevTools
+   console**.
+3. A small panel appears. Run one availability search, then press **Run the
+   summer scan**. It lists every open stay and can copy them to your clipboard.
 
-The resort books through **Campspot**, whose real-time availability sits behind
-a paid, authenticated API and bot protection. Browsers also block cross-site
-reads of the booking page (CORS). A free static page can't reliably pull live
-data — but since the booking calendar shows booked nights visually, marking
-them takes only seconds.
+The script logs the first API response to the console; if results look wrong,
+adjust the "unit keyword" to match how the cottage appears in that response.
+
+### Manual fallback
+
+If the auto-scan can't read the API (e.g. the site changes), there's a manual
+night-calendar mode: mark nights free/booked yourself and it computes every
+open stay of your preferred lengths.
 
 ## Files
 
-- `index.html` — markup and copy
-- `styles.css` — styling (seaside palette, nightly calendar, print stylesheet)
-- `script.js` — calendar state, open-stay computation, link learning, persistence
+- `index.html` — preferences UI + script/bookmarklet generator + manual mode
+- `auto-check.js` — the in-browser automation (console / bookmarklet)
+- `script.js` — page controller (config generation, manual calendar)
+- `styles.css` — styling
+
+## Is this OK to run?
+
+The checker only replays the same availability searches you could do by hand,
+from your own logged-in browser, with a delay between calls. It **reads**
+availability — it never books anything. Keep the throttle reasonable.
 
 ## Privacy
 
-Everything runs client-side. No analytics, no backend. The only network
-requests are the booking links you choose to open.
+Everything runs client-side. Settings and any marked nights are stored only in
+your browser. Nothing is sent anywhere except the booking site's own API, from
+your browser.
 
 > Not affiliated with Sun Outdoors, Sun Retreats, or Campspot. Always confirm
 > availability and book on the official site.

--- a/seashore-cottage-finder/README.md
+++ b/seashore-cottage-finder/README.md
@@ -1,0 +1,63 @@
+# 🏖️ Seashore Cottage Finder
+
+A tiny, no-backend web tool that makes it practical to hunt for an open
+**Premium Cottage (2 Bedroom)** at
+[Sun Retreats Seashore](https://www.sunoutdoors.com/new-jersey/sun-retreats-seashore)
+across a whole summer — instead of fighting the resort's date picker one
+date at a time.
+
+## The problem it solves
+
+The resort's booking page only checks **one date range at a time**. If you're
+flexible on dates but want a specific unit, finding vacancy means repeatedly
+re-entering dates and re-reading the results. Painful.
+
+This tool flips it around: pick your summer window and the stay lengths you'd
+accept, and it generates a **checklist of every possible stay window**, each
+with a one-click link straight into the booking page — plus a place to record
+what you found, saved in your browser.
+
+## How to use it
+
+1. **Set your search** — earliest check-in, latest check-out, stay lengths
+   (e.g. 2/3/4/7 nights), and whether you only care about weekend check-ins.
+2. **Teach it your booking link _(recommended)_** — open the booking page once,
+   pick *any* dates, copy the URL from your address bar, and paste it in. The
+   tool learns the exact link format so every generated link lands on the right
+   dates automatically.
+3. **Build my date checklist** — work down the list, click **Open ↗** for each
+   window, and set its status (✅ Open / ❌ Full / 🤔 Maybe). Filter to
+   **“Open” only** to see your shortlist, then **Copy open dates** or
+   **Print**.
+
+Your settings, learned link, and statuses persist in `localStorage` — close the
+tab and pick up where you left off.
+
+## Why it doesn't fully auto-check availability
+
+Sun Retreats Seashore books through **Campspot**. Real-time availability sits
+behind a **paid, authenticated API** and bot protection, and browsers block
+cross-site reads of the booking page (CORS). So a free static page can't
+reliably read live availability.
+
+There *is* an **experimental “Attempt live auto-check”** button. It tries to
+fetch each booking link from your browser and reports whether the request was
+reachable or blocked. In practice it's usually blocked — and even a reachable
+response doesn't prove a cottage is free — so the dependable workflow remains:
+open each link, glance, and tick. An **Advanced** section lets you route
+requests through your own CORS proxy if you have one.
+
+## Files
+
+- `index.html` — markup and copy
+- `styles.css` — styling (seaside palette, print stylesheet for the checklist)
+- `script.js` — date-window generation, link learning, persistence, live-check
+
+## Privacy
+
+Everything runs client-side. No analytics, no backend. The only network
+requests are the booking links you choose to open and any live-checks you
+trigger.
+
+> Not affiliated with Sun Outdoors, Sun Retreats, or Campspot. Always confirm
+> availability and book on the official site.

--- a/seashore-cottage-finder/README.md
+++ b/seashore-cottage-finder/README.md
@@ -1,63 +1,55 @@
 # 🏖️ Seashore Cottage Finder
 
-A tiny, no-backend web tool that makes it practical to hunt for an open
-**Premium Cottage (2 Bedroom)** at
-[Sun Retreats Seashore](https://www.sunoutdoors.com/new-jersey/sun-retreats-seashore)
-across a whole summer — instead of fighting the resort's date picker one
-date at a time.
+A tiny, no-backend web tool for finding an open **Premium Cottage (2 Bedroom)**
+at [Sun Retreats Seashore](https://www.sunoutdoors.com/new-jersey/sun-retreats-seashore)
+across a whole summer — without clicking through hundreds of date combinations.
 
-## The problem it solves
+## The insight
 
-The resort's booking page only checks **one date range at a time**. If you're
-flexible on dates but want a specific unit, finding vacancy means repeatedly
-re-entering dates and re-reading the results. Painful.
+Availability is **per night**, not per stay window. The resort's booking
+calendar greys out nights that are already taken — a whole month at a glance.
+So instead of checking every possible check-in/check-out combination, you only
+need to know which individual nights are booked. From that, *every* open stay
+window can be computed.
 
-This tool flips it around: pick your summer window and the stay lengths you'd
-accept, and it generates a **checklist of every possible stay window**, each
-with a one-click link straight into the booking page — plus a place to record
-what you found, saved in your browser.
+## How it works
 
-## How to use it
+1. **Trip preferences** — set your summer range, the stay lengths you'd accept
+   (2/3/4/7 nights), guests, and whether you only want weekend check-ins.
+2. **Teach it your booking link** *(optional)* — paste one booking URL that
+   already has dates in it, so the generated "Book ↗" links land on the exact
+   dates.
+3. **Mark the booked nights** — open the resort calendar (a link is provided per
+   month), and click the greyed-out nights here to mark them **Booked**. Then
+   hit *"Mark the rest as free."* That's roughly a dozen clicks for a summer.
+4. **Your open stays** — the tool instantly lists every stay that fits your
+   trip length and touches only free nights, each with a one-click booking
+   link. Copy or print the list.
 
-1. **Set your search** — earliest check-in, latest check-out, stay lengths
-   (e.g. 2/3/4/7 nights), and whether you only care about weekend check-ins.
-2. **Teach it your booking link _(recommended)_** — open the booking page once,
-   pick *any* dates, copy the URL from your address bar, and paste it in. The
-   tool learns the exact link format so every generated link lands on the right
-   dates automatically.
-3. **Build my date checklist** — work down the list, click **Open ↗** for each
-   window, and set its status (✅ Open / ❌ Full / 🤔 Maybe). Filter to
-   **“Open” only** to see your shortlist, then **Copy open dates** or
-   **Print**.
+Nights cycle **Unknown → Free → Booked → Unknown** on click. Stays touching a
+booked night are dropped automatically; stays with still-unchecked nights show
+as "🤔 Check" if you enable that view.
 
-Your settings, learned link, and statuses persist in `localStorage` — close the
-tab and pick up where you left off.
+Everything persists in `localStorage`, so you can come back later.
 
-## Why it doesn't fully auto-check availability
+## Why it doesn't read availability automatically
 
-Sun Retreats Seashore books through **Campspot**. Real-time availability sits
-behind a **paid, authenticated API** and bot protection, and browsers block
-cross-site reads of the booking page (CORS). So a free static page can't
-reliably read live availability.
-
-There *is* an **experimental “Attempt live auto-check”** button. It tries to
-fetch each booking link from your browser and reports whether the request was
-reachable or blocked. In practice it's usually blocked — and even a reachable
-response doesn't prove a cottage is free — so the dependable workflow remains:
-open each link, glance, and tick. An **Advanced** section lets you route
-requests through your own CORS proxy if you have one.
+The resort books through **Campspot**, whose real-time availability sits behind
+a paid, authenticated API and bot protection. Browsers also block cross-site
+reads of the booking page (CORS). A free static page can't reliably pull live
+data — but since the booking calendar shows booked nights visually, marking
+them takes only seconds.
 
 ## Files
 
 - `index.html` — markup and copy
-- `styles.css` — styling (seaside palette, print stylesheet for the checklist)
-- `script.js` — date-window generation, link learning, persistence, live-check
+- `styles.css` — styling (seaside palette, nightly calendar, print stylesheet)
+- `script.js` — calendar state, open-stay computation, link learning, persistence
 
 ## Privacy
 
 Everything runs client-side. No analytics, no backend. The only network
-requests are the booking links you choose to open and any live-checks you
-trigger.
+requests are the booking links you choose to open.
 
 > Not affiliated with Sun Outdoors, Sun Retreats, or Campspot. Always confirm
 > availability and book on the official site.

--- a/seashore-cottage-finder/auto-check.js
+++ b/seashore-cottage-finder/auto-check.js
@@ -1,0 +1,237 @@
+/* ==================================================================
+ * Seashore Cottage Finder — in-browser auto-checker
+ *
+ * This runs INSIDE your browser on the Sun Retreats Seashore booking
+ * site (paste into the DevTools console, or use it as a bookmarklet).
+ * Running here means requests are same-origin and carry your real
+ * session cookies, so they pass the site's Akamai bot protection and
+ * hit the exact same availability API the page already uses — which a
+ * normal web page or a server cannot do.
+ *
+ * How it works:
+ *   1. It quietly watches the site's network calls.
+ *   2. You run ONE normal availability search on the page (any dates).
+ *   3. It learns that request, then replays it across every date in
+ *      your summer range and lists which ones have the cottage open.
+ *
+ * The CONFIG block below is replaced with your settings when you copy
+ * this from the Cottage Finder page. You can also edit it by hand.
+ * ================================================================== */
+(function () {
+  'use strict';
+  if (window.__SCF_LOADED__) { window.__scfPanel && window.__scfPanel(); return; }
+  window.__SCF_LOADED__ = true;
+
+  /*__CONFIG__*/
+  var CONFIG = {
+    start: '2026-06-21',     // earliest check-in (YYYY-MM-DD)
+    end: '2026-09-07',       // latest check-out (YYYY-MM-DD)
+    lengths: [2, 3, 4, 7],   // stay lengths (nights) you'd accept
+    dow: 'any',              // 'any' | 'weekend' | 'weekday' (check-in day)
+    unitKeyword: 'Premium Cottage', // text that marks the cottage as present/available
+    throttleMs: 450          // pause between API calls (be polite)
+  };
+  /*__END_CONFIG__*/
+
+  /* ----------------------------- helpers ------------------------- */
+  function iso(d) {
+    return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+  }
+  function fromISO(s) { var p = s.split('-').map(Number); return new Date(p[0], p[1] - 1, p[2], 12); }
+  function addDays(d, n) { var o = new Date(d); o.setDate(o.getDate() + n); return o; }
+  function sleep(ms) { return new Promise(function (r) { setTimeout(r, ms); }); }
+  var WD = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  var MO = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  function pretty(d) { return WD[d.getDay()] + ' ' + MO[d.getMonth()] + ' ' + d.getDate(); }
+
+  /* --------------------- capture the API request ----------------- */
+  // We record the most recent JSON request that looks like an
+  // availability/search call, including its URL, method, headers and body.
+  var captured = null;
+
+  function looksAvail(url, body) {
+    var s = (String(url || '') + ' ' + String(body || '')).toLowerCase();
+    return /(avail|search|reservation|rates?|booking|grid|sites?|units?|stay)/.test(s) &&
+           /\d{4}-\d{2}-\d{2}|\d{1,2}\/\d{1,2}\/\d{4}/.test(s); // must contain a date
+  }
+  function record(method, url, headers, body) {
+    captured = { method: (method || 'GET').toUpperCase(), url: String(url), headers: headers || {}, body: (typeof body === 'string' ? body : null) };
+    setStatus('Learned a search request ✔  — now press “Run the summer scan”.', 'ok');
+  }
+
+  // hook fetch
+  var ofetch = window.fetch;
+  window.fetch = function (input, init) {
+    init = init || {};
+    var url = (typeof input === 'string') ? input : (input && input.url);
+    var method = init.method || (input && input.method) || 'GET';
+    var body = init.body;
+    var headersObj = headersToObj(init.headers || (input && input.headers));
+    var p = ofetch.apply(this, arguments);
+    try {
+      if (looksAvail(url, typeof body === 'string' ? body : '')) {
+        p.then(function (res) {
+          try { if ((res.headers.get('content-type') || '').indexOf('json') >= 0) record(method, url, headersObj, typeof body === 'string' ? body : null); } catch (e) {}
+        });
+      }
+    } catch (e) {}
+    return p;
+  };
+
+  // hook XHR (covers axios and older code)
+  var OX = window.XMLHttpRequest;
+  var oOpen = OX.prototype.open, oSend = OX.prototype.send, oSet = OX.prototype.setRequestHeader;
+  OX.prototype.open = function (m, u) { this.__scf = { method: m, url: u, headers: {} }; return oOpen.apply(this, arguments); };
+  OX.prototype.setRequestHeader = function (k, v) { if (this.__scf) this.__scf.headers[k] = v; return oSet.apply(this, arguments); };
+  OX.prototype.send = function (body) {
+    var self = this;
+    if (self.__scf && looksAvail(self.__scf.url, typeof body === 'string' ? body : '')) {
+      self.addEventListener('load', function () {
+        try { if ((self.getResponseHeader('content-type') || '').indexOf('json') >= 0) record(self.__scf.method, self.__scf.url, self.__scf.headers, typeof body === 'string' ? body : null); } catch (e) {}
+      });
+    }
+    return oSend.apply(this, arguments);
+  };
+
+  function headersToObj(h) {
+    var o = {};
+    try {
+      if (!h) return o;
+      if (typeof Headers !== 'undefined' && h instanceof Headers) { h.forEach(function (v, k) { o[k] = v; }); }
+      else if (Array.isArray(h)) { h.forEach(function (p) { o[p[0]] = p[1]; }); }
+      else { Object.keys(h).forEach(function (k) { o[k] = h[k]; }); }
+    } catch (e) {}
+    return o;
+  }
+
+  /* ------------------- templatise the captured dates ------------- */
+  // Find the two dates in the captured URL+body, replace earliest with
+  // {CI} and latest with {CO}, and remember their format so we can
+  // re-render each candidate window the same way.
+  function makeTemplate() {
+    if (!captured) return null;
+    var hay = captured.url + '\n' + (captured.body || '');
+    var found = [];
+    var reIso = /\d{4}-\d{2}-\d{2}/g, reUs = /\d{1,2}\/\d{1,2}\/\d{4}/g, m;
+    while ((m = reIso.exec(hay))) found.push({ s: m[0], fmt: 'iso', d: fromISO(m[0]) });
+    if (found.length < 2) { while ((m = reUs.exec(hay))) { var pr = m[0].split('/').map(Number); found.push({ s: m[0], fmt: 'us', d: new Date(pr[2], pr[0] - 1, pr[1], 12) }); } }
+    if (found.length < 2) return null;
+    found.sort(function (a, b) { return a.d - b.d; });
+    var ci = found[0], co = found[found.length - 1];
+    var fmt = ci.fmt;
+    function tmpl(str) { return str.split(ci.s).join('{CI}').split(co.s).join('{CO}'); }
+    return {
+      method: captured.method,
+      urlTmpl: tmpl(captured.url),
+      bodyTmpl: captured.body ? tmpl(captured.body) : null,
+      headers: captured.headers,
+      fmt: fmt
+    };
+  }
+  function fmtDate(d, fmt) { return fmt === 'us' ? (d.getMonth() + 1) + '/' + d.getDate() + '/' + d.getFullYear() : iso(d); }
+
+  /* ------------------------ window generation -------------------- */
+  function dowOk(d) {
+    var k = d.getDay();
+    if (CONFIG.dow === 'weekend') return k === 5 || k === 6;
+    if (CONFIG.dow === 'weekday') return k >= 0 && k <= 4;
+    return true;
+  }
+  function windows() {
+    var start = fromISO(CONFIG.start), end = fromISO(CONFIG.end), out = [];
+    for (var d = new Date(start); d < end; d = addDays(d, 1)) {
+      if (!dowOk(d)) continue;
+      for (var i = 0; i < CONFIG.lengths.length; i++) {
+        var n = CONFIG.lengths[i], co = addDays(d, n);
+        if (co > end) continue;
+        out.push({ ci: new Date(d), co: co, n: n });
+      }
+    }
+    return out;
+  }
+
+  /* ----------------------------- the scan ------------------------ */
+  var running = false, cancel = false;
+  async function run() {
+    var t = makeTemplate();
+    if (!t) { setStatus('No search learned yet. Do one normal availability search on this page (pick any dates, hit search), then press Run.', 'warn'); return; }
+    if (running) { cancel = true; return; }
+    running = true; cancel = false;
+    var btn = document.getElementById('scf-run'); if (btn) btn.textContent = 'Stop';
+
+    var wins = windows();
+    var open = [], errors = 0, sampleLogged = false;
+    for (var i = 0; i < wins.length; i++) {
+      if (cancel) { setStatus('Stopped at ' + i + ' of ' + wins.length + '.', 'warn'); break; }
+      var w = wins[i];
+      var ciS = fmtDate(w.ci, t.fmt), coS = fmtDate(w.co, t.fmt);
+      var url = t.urlTmpl.split('{CI}').join(encodeMaybe(t.urlTmpl, ciS)).split('{CO}').join(encodeMaybe(t.urlTmpl, coS));
+      var body = t.bodyTmpl ? t.bodyTmpl.split('{CI}').join(ciS).split('{CO}').join(coS) : undefined;
+      try {
+        var res = await ofetch(url, { method: t.method, headers: t.headers, body: body, credentials: 'include' });
+        var txt = await res.text();
+        if (!sampleLogged) { console.log('%c[Cottage Finder] sample response (first 2000 chars):', 'color:#0b6e7a;font-weight:bold'); console.log(txt.slice(0, 2000)); sampleLogged = true; }
+        if (txt.toLowerCase().indexOf(CONFIG.unitKeyword.toLowerCase()) >= 0) open.push(w);
+      } catch (e) { errors++; }
+      setStatus('Scanning… ' + (i + 1) + '/' + wins.length + '  ·  ' + open.length + ' open  ·  ' + errors + ' errors', '');
+      renderList(open);
+      await sleep(CONFIG.throttleMs);
+    }
+    running = false; if (btn) btn.textContent = 'Run the summer scan';
+    if (!cancel) setStatus('Done. ' + open.length + ' open stay window(s) found across ' + wins.length + ' checked. ' + (open.length === 0 ? 'If you expected some, the “unit keyword” may not match — check the sample response logged in the console and edit it in the panel.' : ''), open.length ? 'ok' : 'warn');
+    renderList(open);
+  }
+  // If a date sits in a query string it should be URL-encoded; if in a path, leave as-is. Heuristic: encode when the template has '?'.
+  function encodeMaybe(tmpl, s) { return tmpl.indexOf('?') >= 0 ? encodeURIComponent(s) : s; }
+
+  /* ---------------------------- the panel ------------------------ */
+  var lastOpen = [];
+  function renderList(open) {
+    lastOpen = open;
+    var box = document.getElementById('scf-results');
+    if (!box) return;
+    if (!open.length) { box.innerHTML = '<div style="color:#888">No open stays yet…</div>'; return; }
+    box.innerHTML = open.map(function (w) {
+      return '<div>✅ <b>' + pretty(w.ci) + '</b> → ' + pretty(w.co) + ' <span style="color:#888">(' + w.n + ' night' + (w.n > 1 ? 's' : '') + ')</span></div>';
+    }).join('');
+  }
+  function copyOpen() {
+    var text = lastOpen.map(function (w) { return pretty(w.ci) + ' ' + w.ci.getFullYear() + ' → ' + pretty(w.co) + ' (' + w.n + ' nights)'; }).join('\n');
+    navigator.clipboard.writeText(text || 'No open stays found.').then(function () { setStatus('Copied ' + lastOpen.length + ' open stays to clipboard.', 'ok'); });
+  }
+
+  var statusEl;
+  function setStatus(msg, cls) { if (statusEl) { statusEl.textContent = msg; statusEl.style.color = cls === 'ok' ? '#0a7d68' : cls === 'warn' ? '#b3402a' : '#333'; } }
+
+  function panel() {
+    if (document.getElementById('scf-panel')) { document.getElementById('scf-panel').style.display = 'block'; return; }
+    var p = document.createElement('div');
+    p.id = 'scf-panel';
+    p.style.cssText = 'position:fixed;right:16px;bottom:16px;z-index:2147483647;width:330px;max-height:80vh;overflow:auto;background:#fff;border:1px solid #cdd;border-radius:12px;box-shadow:0 8px 30px rgba(0,0,0,.25);font:13px/1.5 -apple-system,Segoe UI,Roboto,sans-serif;color:#20323a;padding:14px';
+    p.innerHTML =
+      '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">' +
+        '<b style="color:#0b6e7a">🏖️ Cottage Finder</b>' +
+        '<span id="scf-x" style="cursor:pointer;color:#888;font-size:16px">✕</span></div>' +
+      '<ol style="margin:0 0 8px 18px;padding:0;color:#5d7079">' +
+        '<li>Run one normal availability search on this page.</li>' +
+        '<li>Press <b>Run the summer scan</b>.</li></ol>' +
+      '<label style="font-weight:600">Unit keyword</label>' +
+      '<input id="scf-kw" style="width:100%;margin:2px 0 8px;padding:6px;border:1px solid #cdd;border-radius:6px" />' +
+      '<div style="display:flex;gap:6px;margin-bottom:8px">' +
+        '<button id="scf-run" style="flex:1;padding:8px;border:0;border-radius:6px;background:#0b6e7a;color:#fff;font-weight:600;cursor:pointer">Run the summer scan</button>' +
+        '<button id="scf-copy" style="padding:8px;border:1px solid #cdd;border-radius:6px;background:#fff;cursor:pointer">Copy</button></div>' +
+      '<div id="scf-status" style="min-height:2.4em;margin-bottom:8px"></div>' +
+      '<div id="scf-results" style="border-top:1px solid #eee;padding-top:8px;font-size:12px"></div>';
+    document.body.appendChild(p);
+    statusEl = document.getElementById('scf-status');
+    document.getElementById('scf-kw').value = CONFIG.unitKeyword;
+    document.getElementById('scf-kw').addEventListener('input', function () { CONFIG.unitKeyword = this.value; });
+    document.getElementById('scf-run').addEventListener('click', run);
+    document.getElementById('scf-copy').addEventListener('click', copyOpen);
+    document.getElementById('scf-x').addEventListener('click', function () { p.style.display = 'none'; });
+    setStatus('Watching for a search… run one availability search on this page to begin.', '');
+  }
+  window.__scfPanel = panel;
+  panel();
+  console.log('%c[Cottage Finder] loaded. Do one availability search on the page, then press “Run the summer scan”.', 'color:#0b6e7a;font-weight:bold');
+})();

--- a/seashore-cottage-finder/index.html
+++ b/seashore-cottage-finder/index.html
@@ -4,22 +4,18 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Seashore Cottage Finder</title>
-    <meta name="description" content="Scan a whole summer for open dates at Sun Retreats Seashore. Mark booked nights once; it computes every open stay for you.">
+    <meta name="description" content="Automatically scan a whole summer for an open cottage at Sun Retreats Seashore by replaying the booking site's own availability API in your browser.">
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <div class="container">
         <header>
             <h1>🏖️ Seashore Cottage Finder</h1>
-            <p class="subtitle">Find open dates for a <strong>Premium Cottage (2&nbsp;Bedroom)</strong> at Sun Retreats Seashore &mdash; mark the booked nights once, and it lists every open stay for you.</p>
+            <p class="subtitle">Automatically scan a whole summer for an open <strong>Premium Cottage (2&nbsp;Bedroom)</strong> at Sun Retreats Seashore &mdash; the machine does the date-by-date checking, not you.</p>
         </header>
 
         <div class="callout">
-            <p><strong>You don't click through hundreds of date combinations.</strong> The resort's booking calendar greys out nights that are already taken &mdash; a whole month at a glance. So you only do this: open the calendar (3 quick pages for the summer), <em>tick the booked nights</em> here, and this tool instantly computes <em>every</em> open stay that fits your trip length. Roughly a dozen clicks, not hundreds.</p>
-            <details>
-                <summary>Why can't it read availability automatically?</summary>
-                <p>The resort books through Campspot, whose live availability sits behind a paid, authenticated API and bot protection. A free page like this can't reliably read it from your browser (cross-site security blocks it). But you can: the calendar shows booked nights visually, so marking them takes seconds.</p>
-            </details>
+            <p><strong>Yes, we can hit the site's own API &mdash; but only from inside your browser.</strong> The booking site sits behind Akamai bot protection, so a normal web page or a server gets blocked (<code>403 Access Denied</code>). The fix: a small script that runs <em>on the booking page itself</em>, where requests are same-origin and carry your real session &mdash; so they pass straight through to the exact availability API the site uses. It watches one search you do, learns the request, then replays it across the whole summer for you.</p>
         </div>
 
         <main>
@@ -50,81 +46,94 @@
                     </div>
                     <p class="hint">Check several &mdash; "flexible" just means leave more boxes ticked.</p>
                 </div>
-                <div class="field">
-                    <label for="dow-filter">Check-in day</label>
-                    <select id="dow-filter">
-                        <option value="any">Any day</option>
-                        <option value="weekend">Weekends only (Fri / Sat check-in)</option>
-                        <option value="weekday">Weekdays only (Sun&ndash;Thu check-in)</option>
-                    </select>
-                </div>
-                <div class="actions">
-                    <button id="build-btn" class="btn btn-primary">Build my availability calendar</button>
-                    <button id="reset-btn" class="btn btn-ghost">Reset everything</button>
+                <div class="grid">
+                    <div class="field">
+                        <label for="dow-filter">Check-in day</label>
+                        <select id="dow-filter">
+                            <option value="any">Any day</option>
+                            <option value="weekend">Weekends only (Fri / Sat)</option>
+                            <option value="weekday">Weekdays only (Sun&ndash;Thu)</option>
+                        </select>
+                    </div>
+                    <div class="field">
+                        <label for="unit-keyword">Unit keyword</label>
+                        <input type="text" id="unit-keyword" value="Premium Cottage">
+                        <p class="hint">Text that identifies your cottage in results.</p>
+                    </div>
                 </div>
             </section>
 
-            <!-- STEP 2: Teach the link (optional) -->
+            <!-- STEP 2: Automated checker -->
             <section class="card">
-                <h2><span class="step">2</span> Teach it your booking link <span class="optional">optional</span></h2>
-                <p>Open the booking page once, pick any dates, and copy the URL from your address bar. Paste it below so the "Book ↗" links on your open-stay list land on the exact dates. Skip this and links open the booking page for you to set dates.</p>
-                <div class="field">
-                    <textarea id="template-url" rows="3" placeholder="Paste a booking URL that already has dates in it, e.g. https://www.sunoutdoors.com/book/checkavailability/236/nj/sun-retreats-seashore?..."></textarea>
-                </div>
-                <div class="actions">
-                    <button id="learn-btn" class="btn btn-secondary">Learn this link</button>
-                    <a id="open-booking" class="btn btn-ghost" href="https://www.sunoutdoors.com/book/checkavailability/236/nj/sun-retreats-seashore" target="_blank" rel="noopener">Open booking page ↗</a>
-                </div>
-                <p id="template-status" class="status-line"></p>
+                <h2><span class="step">2</span> Run the automatic scan <span class="optional">recommended</span></h2>
+                <p>This is the hands-off way. The checker runs on the booking site and does every date lookup for you.</p>
+
+                <ol class="how">
+                    <li><a id="open-booking" href="https://www.sunoutdoors.com/book/checkavailability/236/nj/sun-retreats-seashore" target="_blank" rel="noopener"><strong>Open the booking page ↗</strong></a> and sign in / get to the cottage search.</li>
+                    <li>Load the checker onto that page &mdash; pick one:
+                        <div class="loader-options">
+                            <div class="loader">
+                                <strong>A. Bookmarklet (easiest)</strong>
+                                <p>Drag this to your bookmarks bar, then click it while on the booking page:</p>
+                                <a id="bookmarklet" class="bookmarklet" href="#">🏖️ Cottage Finder</a>
+                            </div>
+                            <div class="loader">
+                                <strong>B. Console paste</strong>
+                                <p>Open DevTools (F12) → Console, paste the script, press Enter:</p>
+                                <button id="copy-script" class="btn btn-secondary">Copy the checker script</button>
+                            </div>
+                        </div>
+                    </li>
+                    <li>A little <strong>🏖️ Cottage Finder</strong> panel appears. <strong>Do one normal availability search</strong> on the page (any dates) so it can learn the request.</li>
+                    <li>Press <strong>Run the summer scan</strong>. It lists every open stay and can copy them to your clipboard.</li>
+                </ol>
+                <p id="gen-status" class="status-line"></p>
+
+                <details class="advanced">
+                    <summary>See / tweak the generated script</summary>
+                    <p class="hint">This is the exact code, configured with your settings above. Re-copy after changing any preference. Throttle (ms between calls): <input type="number" id="throttle" value="450" min="150" max="3000" style="width:90px"></p>
+                    <textarea id="script-preview" rows="10" readonly spellcheck="false"></textarea>
+                </details>
             </section>
 
-            <!-- STEP 3: Mark the calendar -->
-            <section class="card" id="calendar-card" hidden>
-                <h2><span class="step">3</span> Mark the booked nights</h2>
-                <p>Open the booking calendar (button above), look for the greyed-out / unavailable nights, and click those same nights below to mark them <strong>Booked</strong>. Click again to cycle Free → Booked → Unknown. When you've marked everything you can see, hit <em>"Mark the rest as free."</em></p>
-                <div class="legend">
-                    <span class="swatch free"></span> Free
-                    <span class="swatch booked"></span> Booked
-                    <span class="swatch unknown"></span> Unknown (not yet checked)
-                </div>
-                <div class="actions">
-                    <button id="rest-free-btn" class="btn btn-secondary">Mark the rest as free</button>
-                    <button id="all-unknown-btn" class="btn btn-ghost">Clear all marks</button>
-                </div>
-                <div id="calendar" class="calendar"></div>
-            </section>
-
-            <!-- STEP 4: Open stays -->
-            <section class="card" id="results-card" hidden>
-                <div class="results-head">
-                    <h2><span class="step">4</span> Your open stays</h2>
-                    <label class="inline"><input type="checkbox" id="show-partial"> Also show stays with unchecked nights</label>
-                </div>
-                <div class="summary-bar" id="summary-bar"></div>
-                <div class="actions live-actions">
-                    <button id="copy-btn" class="btn btn-ghost">Copy list</button>
-                    <button id="print-btn" class="btn btn-ghost">Print</button>
-                </div>
-                <div class="table-wrap">
-                    <table id="results-table">
-                        <thead>
-                            <tr><th>Check-in</th><th>Check-out</th><th>Nights</th><th>Status</th><th>Book</th></tr>
-                        </thead>
-                        <tbody id="results-body"></tbody>
-                    </table>
-                </div>
+            <!-- STEP 3: Manual fallback -->
+            <section class="card">
+                <details id="manual-wrap">
+                    <summary><h2 style="display:inline"><span class="step">3</span> Manual fallback</h2> &mdash; if the auto-scan can't read the API</summary>
+                    <p>Pick dates on the booking site yourself and record what you find here; it computes every open stay from the nights you mark. <button id="build-btn" class="btn btn-ghost">Build calendar</button></p>
+                    <div id="manual-body" hidden>
+                        <div class="legend">
+                            <span class="swatch free"></span> Free
+                            <span class="swatch booked"></span> Booked
+                            <span class="swatch unknown"></span> Not checked
+                            <span class="hint">(click a night to cycle)</span>
+                        </div>
+                        <div class="actions">
+                            <button id="rest-free-btn" class="btn btn-ghost">Mark remaining free</button>
+                            <button id="all-unknown-btn" class="btn btn-ghost">Clear marks</button>
+                        </div>
+                        <div id="calendar" class="calendar"></div>
+                        <div class="summary-bar" id="summary-bar"></div>
+                        <div class="table-wrap">
+                            <table>
+                                <thead><tr><th>Check-in</th><th>Check-out</th><th>Nights</th><th>Status</th><th>Book</th></tr></thead>
+                                <tbody id="results-body"></tbody>
+                            </table>
+                        </div>
+                    </div>
+                </details>
             </section>
 
             <section class="card">
                 <details>
-                    <summary><strong>About & privacy</strong></summary>
-                    <p class="hint">Everything runs in your browser. Your preferences, learned link, and the nights you mark are saved only in this browser's localStorage &mdash; nothing is sent anywhere except the booking links you choose to open.</p>
+                    <summary><strong>Is this allowed? &amp; privacy</strong></summary>
+                    <p class="hint">The checker only replays the same availability searches you could do by hand, from your own logged-in browser, with a polite delay between calls &mdash; it reads availability, it does not book anything. Go easy on the throttle. Everything runs client-side; your settings and any marked nights are saved only in this browser. This is a personal planning aid and is not affiliated with Sun Outdoors, Sun Retreats, or Campspot &mdash; always confirm and book on the official site.</p>
                 </details>
             </section>
         </main>
 
         <footer>
-            <p>Not affiliated with Sun Outdoors, Sun Retreats, or Campspot. A personal planning aid &mdash; always confirm availability and book on the official site.</p>
+            <p>A personal planning aid. Always confirm availability and book on the official site.</p>
         </footer>
     </div>
     <script src="script.js"></script>

--- a/seashore-cottage-finder/index.html
+++ b/seashore-cottage-finder/index.html
@@ -4,29 +4,28 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Seashore Cottage Finder</title>
-    <meta name="description" content="Scan a whole summer for open dates at Sun Retreats Seashore instead of checking one date at a time.">
+    <meta name="description" content="Scan a whole summer for open dates at Sun Retreats Seashore. Mark booked nights once; it computes every open stay for you.">
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <div class="container">
         <header>
             <h1>🏖️ Seashore Cottage Finder</h1>
-            <p class="subtitle">Find open dates for a <strong>Premium Cottage (2&nbsp;Bedroom)</strong> at Sun Retreats Seashore &mdash; scan the whole summer instead of one date at a time.</p>
+            <p class="subtitle">Find open dates for a <strong>Premium Cottage (2&nbsp;Bedroom)</strong> at Sun Retreats Seashore &mdash; mark the booked nights once, and it lists every open stay for you.</p>
         </header>
 
         <div class="callout">
-            <p><strong>How this works.</strong> The resort's own booking page only lets you check one date range at a time, which makes hunting for vacancy painful. This tool builds a checklist of <em>every</em> stay window across the summer, gives you a one-click link straight into the booking page for each, and remembers which dates you found open &mdash; all saved in your browser.</p>
+            <p><strong>You don't click through hundreds of date combinations.</strong> The resort's booking calendar greys out nights that are already taken &mdash; a whole month at a glance. So you only do this: open the calendar (3 quick pages for the summer), <em>tick the booked nights</em> here, and this tool instantly computes <em>every</em> open stay that fits your trip length. Roughly a dozen clicks, not hundreds.</p>
             <details>
-                <summary>Why can't it just check availability automatically?</summary>
-                <p>The resort runs its booking through Campspot. Real-time availability lives behind a paid, authenticated API and bot protection, so a free page like this usually <em>cannot</em> read it directly from your browser (the request gets blocked by the site's security/CORS rules). The tool will still <em>attempt</em> a live check when you ask &mdash; but the dependable path is: open each window's link, glance at the result, and tick it off here. You can also <strong>teach it your booking link</strong> below so the one-click links land on the exact dates automatically.</p>
+                <summary>Why can't it read availability automatically?</summary>
+                <p>The resort books through Campspot, whose live availability sits behind a paid, authenticated API and bot protection. A free page like this can't reliably read it from your browser (cross-site security blocks it). But you can: the calendar shows booked nights visually, so marking them takes seconds.</p>
             </details>
         </div>
 
         <main>
             <!-- STEP 1: Settings -->
             <section class="card">
-                <h2><span class="step">1</span> Set your search</h2>
-
+                <h2><span class="step">1</span> Your trip preferences</h2>
                 <div class="grid">
                     <div class="field">
                         <label for="start-date">Earliest check-in</label>
@@ -41,18 +40,16 @@
                         <input type="number" id="guests" min="1" max="6" value="2">
                     </div>
                 </div>
-
                 <div class="field">
-                    <label>Stay length (nights)</label>
+                    <label>Stay length (nights) you'd accept</label>
                     <div class="chips" id="length-chips">
                         <label class="chip"><input type="checkbox" value="2" checked> 2</label>
                         <label class="chip"><input type="checkbox" value="3" checked> 3</label>
                         <label class="chip"><input type="checkbox" value="4" checked> 4</label>
                         <label class="chip"><input type="checkbox" value="7" checked> 7</label>
                     </div>
-                    <p class="hint">Pick any combination &mdash; "Flexible" means leave several checked.</p>
+                    <p class="hint">Check several &mdash; "flexible" just means leave more boxes ticked.</p>
                 </div>
-
                 <div class="field">
                     <label for="dow-filter">Check-in day</label>
                     <select id="dow-filter">
@@ -61,17 +58,16 @@
                         <option value="weekday">Weekdays only (Sun&ndash;Thu check-in)</option>
                     </select>
                 </div>
-
                 <div class="actions">
-                    <button id="generate-btn" class="btn btn-primary">Build my date checklist</button>
+                    <button id="build-btn" class="btn btn-primary">Build my availability calendar</button>
                     <button id="reset-btn" class="btn btn-ghost">Reset everything</button>
                 </div>
             </section>
 
-            <!-- STEP 2: Teach the link -->
+            <!-- STEP 2: Teach the link (optional) -->
             <section class="card">
-                <h2><span class="step">2</span> Teach it your booking link <span class="optional">optional, but recommended</span></h2>
-                <p>Go to the booking page once, pick <em>any</em> set of dates, and copy the URL from your browser's address bar. Paste it below and this tool will reuse its exact format so every link lands on the right dates. If you skip this, links open the booking page with a best-effort guess.</p>
+                <h2><span class="step">2</span> Teach it your booking link <span class="optional">optional</span></h2>
+                <p>Open the booking page once, pick any dates, and copy the URL from your address bar. Paste it below so the "Book ↗" links on your open-stay list land on the exact dates. Skip this and links open the booking page for you to set dates.</p>
                 <div class="field">
                     <textarea id="template-url" rows="3" placeholder="Paste a booking URL that already has dates in it, e.g. https://www.sunoutdoors.com/book/checkavailability/236/nj/sun-retreats-seashore?..."></textarea>
                 </div>
@@ -82,58 +78,47 @@
                 <p id="template-status" class="status-line"></p>
             </section>
 
-            <!-- STEP 3: Results -->
+            <!-- STEP 3: Mark the calendar -->
+            <section class="card" id="calendar-card" hidden>
+                <h2><span class="step">3</span> Mark the booked nights</h2>
+                <p>Open the booking calendar (button above), look for the greyed-out / unavailable nights, and click those same nights below to mark them <strong>Booked</strong>. Click again to cycle Free → Booked → Unknown. When you've marked everything you can see, hit <em>"Mark the rest as free."</em></p>
+                <div class="legend">
+                    <span class="swatch free"></span> Free
+                    <span class="swatch booked"></span> Booked
+                    <span class="swatch unknown"></span> Unknown (not yet checked)
+                </div>
+                <div class="actions">
+                    <button id="rest-free-btn" class="btn btn-secondary">Mark the rest as free</button>
+                    <button id="all-unknown-btn" class="btn btn-ghost">Clear all marks</button>
+                </div>
+                <div id="calendar" class="calendar"></div>
+            </section>
+
+            <!-- STEP 4: Open stays -->
             <section class="card" id="results-card" hidden>
                 <div class="results-head">
-                    <h2><span class="step">3</span> Your summer checklist</h2>
-                    <div class="results-tools">
-                        <label class="inline"><input type="checkbox" id="show-open-only"> Show only "Open" dates</label>
-                        <select id="filter-status" class="mini">
-                            <option value="all">All statuses</option>
-                            <option value="unknown">Not checked yet</option>
-                            <option value="open">Open</option>
-                            <option value="full">Full</option>
-                            <option value="maybe">Maybe</option>
-                        </select>
-                    </div>
+                    <h2><span class="step">4</span> Your open stays</h2>
+                    <label class="inline"><input type="checkbox" id="show-partial"> Also show stays with unchecked nights</label>
                 </div>
-
                 <div class="summary-bar" id="summary-bar"></div>
-
                 <div class="actions live-actions">
-                    <button id="check-all-btn" class="btn btn-secondary">⚡ Attempt live auto-check (experimental)</button>
-                    <button id="copy-open-btn" class="btn btn-ghost">Copy open dates</button>
-                    <button id="print-btn" class="btn btn-ghost">Print checklist</button>
+                    <button id="copy-btn" class="btn btn-ghost">Copy list</button>
+                    <button id="print-btn" class="btn btn-ghost">Print</button>
                 </div>
-                <p id="live-status" class="status-line"></p>
-
                 <div class="table-wrap">
                     <table id="results-table">
                         <thead>
-                            <tr>
-                                <th>Check-in</th>
-                                <th>Check-out</th>
-                                <th>Nights</th>
-                                <th>Open booking</th>
-                                <th>Status</th>
-                                <th>Notes</th>
-                            </tr>
+                            <tr><th>Check-in</th><th>Check-out</th><th>Nights</th><th>Status</th><th>Book</th></tr>
                         </thead>
                         <tbody id="results-body"></tbody>
                     </table>
                 </div>
             </section>
 
-            <!-- Advanced -->
             <section class="card">
                 <details>
-                    <summary><strong>Advanced</strong> &mdash; live-check settings (for the technically curious)</summary>
-                    <p class="hint">The live auto-check tries to fetch each booking link from your browser. Cross-site security usually blocks this. If you have a CORS proxy you trust, you can route requests through it. Leave blank to attempt a direct request.</p>
-                    <div class="field">
-                        <label for="proxy-url">CORS proxy prefix (optional)</label>
-                        <input type="text" id="proxy-url" placeholder="e.g. https://my-proxy.example/?url=">
-                    </div>
-                    <p class="hint">Your settings, learned link, and date statuses are stored only in this browser (localStorage). Nothing is sent anywhere except the booking links you open and any live-check requests you trigger.</p>
+                    <summary><strong>About & privacy</strong></summary>
+                    <p class="hint">Everything runs in your browser. Your preferences, learned link, and the nights you mark are saved only in this browser's localStorage &mdash; nothing is sent anywhere except the booking links you choose to open.</p>
                 </details>
             </section>
         </main>

--- a/seashore-cottage-finder/index.html
+++ b/seashore-cottage-finder/index.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Seashore Cottage Finder</title>
+    <meta name="description" content="Scan a whole summer for open dates at Sun Retreats Seashore instead of checking one date at a time.">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>🏖️ Seashore Cottage Finder</h1>
+            <p class="subtitle">Find open dates for a <strong>Premium Cottage (2&nbsp;Bedroom)</strong> at Sun Retreats Seashore &mdash; scan the whole summer instead of one date at a time.</p>
+        </header>
+
+        <div class="callout">
+            <p><strong>How this works.</strong> The resort's own booking page only lets you check one date range at a time, which makes hunting for vacancy painful. This tool builds a checklist of <em>every</em> stay window across the summer, gives you a one-click link straight into the booking page for each, and remembers which dates you found open &mdash; all saved in your browser.</p>
+            <details>
+                <summary>Why can't it just check availability automatically?</summary>
+                <p>The resort runs its booking through Campspot. Real-time availability lives behind a paid, authenticated API and bot protection, so a free page like this usually <em>cannot</em> read it directly from your browser (the request gets blocked by the site's security/CORS rules). The tool will still <em>attempt</em> a live check when you ask &mdash; but the dependable path is: open each window's link, glance at the result, and tick it off here. You can also <strong>teach it your booking link</strong> below so the one-click links land on the exact dates automatically.</p>
+            </details>
+        </div>
+
+        <main>
+            <!-- STEP 1: Settings -->
+            <section class="card">
+                <h2><span class="step">1</span> Set your search</h2>
+
+                <div class="grid">
+                    <div class="field">
+                        <label for="start-date">Earliest check-in</label>
+                        <input type="date" id="start-date">
+                    </div>
+                    <div class="field">
+                        <label for="end-date">Latest check-out</label>
+                        <input type="date" id="end-date">
+                    </div>
+                    <div class="field">
+                        <label for="guests">Guests</label>
+                        <input type="number" id="guests" min="1" max="6" value="2">
+                    </div>
+                </div>
+
+                <div class="field">
+                    <label>Stay length (nights)</label>
+                    <div class="chips" id="length-chips">
+                        <label class="chip"><input type="checkbox" value="2" checked> 2</label>
+                        <label class="chip"><input type="checkbox" value="3" checked> 3</label>
+                        <label class="chip"><input type="checkbox" value="4" checked> 4</label>
+                        <label class="chip"><input type="checkbox" value="7" checked> 7</label>
+                    </div>
+                    <p class="hint">Pick any combination &mdash; "Flexible" means leave several checked.</p>
+                </div>
+
+                <div class="field">
+                    <label for="dow-filter">Check-in day</label>
+                    <select id="dow-filter">
+                        <option value="any">Any day</option>
+                        <option value="weekend">Weekends only (Fri / Sat check-in)</option>
+                        <option value="weekday">Weekdays only (Sun&ndash;Thu check-in)</option>
+                    </select>
+                </div>
+
+                <div class="actions">
+                    <button id="generate-btn" class="btn btn-primary">Build my date checklist</button>
+                    <button id="reset-btn" class="btn btn-ghost">Reset everything</button>
+                </div>
+            </section>
+
+            <!-- STEP 2: Teach the link -->
+            <section class="card">
+                <h2><span class="step">2</span> Teach it your booking link <span class="optional">optional, but recommended</span></h2>
+                <p>Go to the booking page once, pick <em>any</em> set of dates, and copy the URL from your browser's address bar. Paste it below and this tool will reuse its exact format so every link lands on the right dates. If you skip this, links open the booking page with a best-effort guess.</p>
+                <div class="field">
+                    <textarea id="template-url" rows="3" placeholder="Paste a booking URL that already has dates in it, e.g. https://www.sunoutdoors.com/book/checkavailability/236/nj/sun-retreats-seashore?..."></textarea>
+                </div>
+                <div class="actions">
+                    <button id="learn-btn" class="btn btn-secondary">Learn this link</button>
+                    <a id="open-booking" class="btn btn-ghost" href="https://www.sunoutdoors.com/book/checkavailability/236/nj/sun-retreats-seashore" target="_blank" rel="noopener">Open booking page ↗</a>
+                </div>
+                <p id="template-status" class="status-line"></p>
+            </section>
+
+            <!-- STEP 3: Results -->
+            <section class="card" id="results-card" hidden>
+                <div class="results-head">
+                    <h2><span class="step">3</span> Your summer checklist</h2>
+                    <div class="results-tools">
+                        <label class="inline"><input type="checkbox" id="show-open-only"> Show only "Open" dates</label>
+                        <select id="filter-status" class="mini">
+                            <option value="all">All statuses</option>
+                            <option value="unknown">Not checked yet</option>
+                            <option value="open">Open</option>
+                            <option value="full">Full</option>
+                            <option value="maybe">Maybe</option>
+                        </select>
+                    </div>
+                </div>
+
+                <div class="summary-bar" id="summary-bar"></div>
+
+                <div class="actions live-actions">
+                    <button id="check-all-btn" class="btn btn-secondary">⚡ Attempt live auto-check (experimental)</button>
+                    <button id="copy-open-btn" class="btn btn-ghost">Copy open dates</button>
+                    <button id="print-btn" class="btn btn-ghost">Print checklist</button>
+                </div>
+                <p id="live-status" class="status-line"></p>
+
+                <div class="table-wrap">
+                    <table id="results-table">
+                        <thead>
+                            <tr>
+                                <th>Check-in</th>
+                                <th>Check-out</th>
+                                <th>Nights</th>
+                                <th>Open booking</th>
+                                <th>Status</th>
+                                <th>Notes</th>
+                            </tr>
+                        </thead>
+                        <tbody id="results-body"></tbody>
+                    </table>
+                </div>
+            </section>
+
+            <!-- Advanced -->
+            <section class="card">
+                <details>
+                    <summary><strong>Advanced</strong> &mdash; live-check settings (for the technically curious)</summary>
+                    <p class="hint">The live auto-check tries to fetch each booking link from your browser. Cross-site security usually blocks this. If you have a CORS proxy you trust, you can route requests through it. Leave blank to attempt a direct request.</p>
+                    <div class="field">
+                        <label for="proxy-url">CORS proxy prefix (optional)</label>
+                        <input type="text" id="proxy-url" placeholder="e.g. https://my-proxy.example/?url=">
+                    </div>
+                    <p class="hint">Your settings, learned link, and date statuses are stored only in this browser (localStorage). Nothing is sent anywhere except the booking links you open and any live-check requests you trigger.</p>
+                </details>
+            </section>
+        </main>
+
+        <footer>
+            <p>Not affiliated with Sun Outdoors, Sun Retreats, or Campspot. A personal planning aid &mdash; always confirm availability and book on the official site.</p>
+        </footer>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/seashore-cottage-finder/script.js
+++ b/seashore-cottage-finder/script.js
@@ -2,42 +2,39 @@
 
 /* ------------------------------------------------------------------ *
  * Seashore Cottage Finder
- * Scans a whole summer for open stay windows at Sun Retreats Seashore
- * (Premium Cottage, 2 Bedroom) so you don't have to check the resort's
- * date picker one date at a time.
  *
- * Everything runs in your browser. Settings, the learned booking link,
- * and per-date statuses are saved to localStorage only.
+ * Key idea: availability is PER NIGHT, not per stay window. The resort's
+ * booking calendar greys out booked nights a whole month at a time. So you
+ * mark the booked nights once (a handful of clicks), and this tool computes
+ * EVERY open stay window that fits your trip length — instead of you clicking
+ * through hundreds of date combinations.
+ *
+ * Everything runs in your browser. Preferences, the learned booking link, and
+ * the nights you mark are saved to localStorage only.
  * ------------------------------------------------------------------ */
 
 const BOOKING_BASE = 'https://www.sunoutdoors.com/book/checkavailability/236/nj/sun-retreats-seashore';
 
 const STORE = {
-  settings: 'scf.settings.v1',
-  template: 'scf.template.v1',
-  statuses: 'scf.statuses.v1',
-  proxy:    'scf.proxy.v1',
+  settings: 'scf.settings.v2',
+  template: 'scf.template.v2',
+  nights:   'scf.nights.v2',   // 'YYYY-MM-DD' -> 'free' | 'booked'  (absent = unknown)
 };
-
-const MAX_ROWS = 600; // safety guard against runaway combinations
 
 /* ----------------------------- helpers ---------------------------- */
 
 const $ = (id) => document.getElementById(id);
 
-// Build a Date at local noon to dodge timezone/DST off-by-one issues.
 function dateFromISO(iso) {
   const [y, m, d] = iso.split('-').map(Number);
   return new Date(y, m - 1, d, 12, 0, 0, 0);
 }
-
 function toISO(date) {
   const y = date.getFullYear();
   const m = String(date.getMonth() + 1).padStart(2, '0');
   const d = String(date.getDate()).padStart(2, '0');
   return `${y}-${m}-${d}`;
 }
-
 function addDays(date, n) {
   const out = new Date(date);
   out.setDate(out.getDate() + n);
@@ -45,61 +42,41 @@ function addDays(date, n) {
 }
 
 const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-                'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June',
+                'July', 'August', 'September', 'October', 'November', 'December'];
+const MON_ABBR = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
 function prettyDate(date) {
-  return `${WEEKDAYS[date.getDay()]} ${MONTHS[date.getMonth()]} ${date.getDate()}`;
+  return `${WEEKDAYS[date.getDay()]} ${MON_ABBR[date.getMonth()]} ${date.getDate()}`;
 }
 
 function load(key, fallback) {
-  try {
-    const raw = localStorage.getItem(key);
-    return raw ? JSON.parse(raw) : fallback;
-  } catch {
-    return fallback;
-  }
+  try { const raw = localStorage.getItem(key); return raw ? JSON.parse(raw) : fallback; }
+  catch { return fallback; }
 }
-
 function save(key, value) {
-  try {
-    localStorage.setItem(key, JSON.stringify(value));
-  } catch { /* storage full or blocked — ignore */ }
-}
-
-function windowKey(checkinISO, nights) {
-  return `${checkinISO}|${nights}`;
+  try { localStorage.setItem(key, JSON.stringify(value)); } catch { /* ignore */ }
 }
 
 /* --------------------------- date format -------------------------- */
-// Recognise date-like strings inside a pasted URL so we can swap them out.
+// Recognise date-like strings in a pasted URL so we can templatise them.
 
 const DATE_PATTERNS = [
-  { name: 'iso', re: /^\d{4}-\d{2}-\d{2}$/, parse: (s) => dateFromISO(s),
-    fmt: (d) => toISO(d) },
+  { name: 'iso', re: /^\d{4}-\d{2}-\d{2}$/, parse: (s) => dateFromISO(s), fmt: (d) => toISO(d) },
   { name: 'us', re: /^\d{1,2}\/\d{1,2}\/\d{4}$/,
     parse: (s) => { const [m, d, y] = s.split('/').map(Number); return new Date(y, m - 1, d, 12); },
     fmt: (d) => `${d.getMonth() + 1}/${d.getDate()}/${d.getFullYear()}` },
 ];
-
 function detectDate(value) {
   for (const p of DATE_PATTERNS) {
-    if (p.re.test(value)) {
-      const dt = p.parse(value);
-      if (!isNaN(dt)) return { pattern: p, date: dt };
-    }
+    if (p.re.test(value)) { const dt = p.parse(value); if (!isNaN(dt)) return { pattern: p, date: dt }; }
   }
   return null;
 }
 
 /* --------------------------- templates ---------------------------- */
-// A template is the booking URL with {CHECKIN}/{CHECKOUT} placeholders,
-// plus the date format to render them in.
 
-function defaultTemplate() {
-  // No guessed date params: a bare link is guaranteed to open the page.
-  return { url: BOOKING_BASE, format: 'iso', learned: false };
-}
+function defaultTemplate() { return { url: BOOKING_BASE, format: 'iso', learned: false }; }
 
 function learnTemplate(rawUrl) {
   const url = new URL(rawUrl.trim());
@@ -109,377 +86,310 @@ function learnTemplate(rawUrl) {
     if (hit) found.push({ key: k, ...hit });
   }
   if (found.length < 2) {
-    throw new Error('Could not find two dates in that URL. Make sure you picked dates on the booking page before copying the link.');
+    throw new Error('Could not find two dates in that URL. Pick dates on the booking page first, then copy the link.');
   }
-  // Earliest date = check-in, latest = check-out.
   found.sort((a, b) => a.date - b.date);
-  const checkinHit = found[0];
-  const checkoutHit = found[found.length - 1];
-
-  url.searchParams.set(checkinHit.key, '{CHECKIN}');
-  url.searchParams.set(checkoutHit.key, '{CHECKOUT}');
-
-  // decodeURIComponent so our placeholders stay readable in the stored string.
-  const templateUrl = decodeURIComponent(url.toString());
-  return { url: templateUrl, format: checkinHit.pattern.name, learned: true };
+  url.searchParams.set(found[0].key, '{CHECKIN}');
+  url.searchParams.set(found[found.length - 1].key, '{CHECKOUT}');
+  return { url: decodeURIComponent(url.toString()), format: found[0].pattern.name, learned: true };
 }
 
-function buildLink(template, checkin, checkout) {
+function buildLink(checkin, checkout) {
+  if (!template.url.includes('{CHECKIN}')) return template.url;
   const fmt = DATE_PATTERNS.find((p) => p.name === template.format) || DATE_PATTERNS[0];
-  if (!template.url.includes('{CHECKIN}')) {
-    return template.url; // bare booking page
-  }
   return template.url
     .replace('{CHECKIN}', encodeURIComponent(fmt.fmt(checkin)))
     .replace('{CHECKOUT}', encodeURIComponent(fmt.fmt(checkout)));
 }
 
-/* --------------------------- generation --------------------------- */
-
-function selectedLengths() {
-  return [...document.querySelectorAll('#length-chips input:checked')]
-    .map((el) => Number(el.value))
-    .sort((a, b) => a - b);
-}
-
-function dowAllowed(date, mode) {
-  const day = date.getDay(); // 0 Sun .. 6 Sat
-  if (mode === 'weekend') return day === 5 || day === 6;
-  if (mode === 'weekday') return day >= 0 && day <= 4;
-  return true;
-}
-
-function generateWindows(settings) {
-  const start = dateFromISO(settings.start);
-  const end = dateFromISO(settings.end);
-  const lengths = settings.lengths;
-  const rows = [];
-
-  for (let d = new Date(start); d <= end; d = addDays(d, 1)) {
-    if (!dowAllowed(d, settings.dow)) continue;
-    for (const nights of lengths) {
-      const checkout = addDays(d, nights);
-      if (checkout > end) continue;
-      rows.push({
-        checkin: new Date(d),
-        checkout,
-        checkinISO: toISO(d),
-        checkoutISO: toISO(checkout),
-        nights,
-      });
-      if (rows.length > MAX_ROWS) return { rows, truncated: true };
-    }
-  }
-  rows.sort((a, b) => a.checkin - b.checkin || a.nights - b.nights);
-  return { rows, truncated: false };
-}
-
 /* ----------------------------- state ------------------------------ */
 
-let currentRows = [];
+let settings = load(STORE.settings, defaultSettings());
 let template = load(STORE.template, defaultTemplate());
-let statuses = load(STORE.statuses, {});   // windowKey -> { status, note }
+let nights = load(STORE.nights, {});   // ISO -> 'free' | 'booked'
 
-/* --------------------------- rendering ---------------------------- */
-
-const STATUS_LABELS = {
-  unknown: 'Not checked',
-  open: '✅ Open',
-  full: '❌ Full',
-  maybe: '🤔 Maybe',
-};
-
-function getStatus(key) {
-  return statuses[key] || { status: 'unknown', note: '' };
+function defaultSettings() {
+  const now = new Date();
+  const year = now.getMonth() > 8 ? now.getFullYear() + 1 : now.getFullYear();
+  return { start: `${year}-06-21`, end: `${year}-09-07`, guests: 2, lengths: [2, 3, 4, 7], dow: 'any' };
 }
 
-function setStatus(key, patch) {
-  statuses[key] = { ...getStatus(key), ...patch };
-  save(STORE.statuses, statuses);
-}
-
-function rowVisible(key) {
-  const openOnly = $('show-open-only').checked;
-  const filter = $('filter-status').value;
-  const st = getStatus(key).status;
-  if (openOnly && st !== 'open') return false;
-  if (filter !== 'all' && st !== filter) return false;
-  return true;
-}
-
-function renderSummary() {
-  const counts = { total: currentRows.length, open: 0, full: 0, maybe: 0, unknown: 0 };
-  for (const r of currentRows) counts[getStatus(windowKey(r.checkinISO, r.nights)).status]++;
-  $('summary-bar').innerHTML = `
-    <span class="pill">${counts.total} windows</span>
-    <span class="pill open">${counts.open} open</span>
-    <span class="pill">${counts.maybe} maybe</span>
-    <span class="pill full">${counts.full} full</span>
-    <span class="pill">${counts.unknown} unchecked</span>`;
-}
-
-function renderTable() {
-  const body = $('results-body');
-  body.innerHTML = '';
-  let shown = 0;
-
-  for (const r of currentRows) {
-    const key = windowKey(r.checkinISO, r.nights);
-    if (!rowVisible(key)) continue;
-    shown++;
-    const st = getStatus(key);
-    const link = buildLink(template, r.checkin, r.checkout);
-
-    const tr = document.createElement('tr');
-    tr.dataset.status = st.status;
-    tr.dataset.key = key;
-
-    tr.innerHTML = `
-      <td>${prettyDate(r.checkin)}<br><small>${r.checkin.getFullYear()}</small></td>
-      <td>${prettyDate(r.checkout)}<br><small>${r.checkout.getFullYear()}</small></td>
-      <td>${r.nights}</td>
-      <td><a class="open-link" href="${link}" target="_blank" rel="noopener">Open ↗</a>
-          <div class="live-cell" data-live></div></td>
-      <td>
-        <select data-status>
-          <option value="unknown">Not checked</option>
-          <option value="open">✅ Open</option>
-          <option value="full">❌ Full</option>
-          <option value="maybe">🤔 Maybe</option>
-        </select>
-      </td>
-      <td><input class="note-input" type="text" data-note placeholder="notes…" value="${escapeAttr(st.note)}"></td>`;
-
-    tr.querySelector('[data-status]').value = st.status;
-    body.appendChild(tr);
-  }
-
-  if (shown === 0) {
-    const tr = document.createElement('tr');
-    tr.innerHTML = `<td colspan="6" style="text-align:center;color:var(--text-muted);padding:24px;">No windows match this filter.</td>`;
-    body.appendChild(tr);
-  }
-  renderSummary();
-}
-
-function escapeAttr(s) {
-  return String(s || '').replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
-}
-
-/* ----------------------------- live check ------------------------- */
-
-let liveRunning = false;
-
-async function liveCheckAll() {
-  if (liveRunning) return;
-  const visibleRows = currentRows.filter((r) => rowVisible(windowKey(r.checkinISO, r.nights)));
-  if (visibleRows.length === 0) return;
-
-  if (!template.learned) {
-    if (!confirm('You haven\'t taught the tool your booking link yet, so the live check can only reach the generic booking page (no dates). It will likely be blocked by the site\'s security. Continue anyway?')) return;
-  }
-  if (visibleRows.length > 60 &&
-      !confirm(`This will attempt ${visibleRows.length} live requests, one at a time. That can take a while and may get blocked. Continue?`)) {
-    return;
-  }
-
-  liveRunning = true;
-  const btn = $('check-all-btn');
-  btn.disabled = true;
-  const proxy = $('proxy-url').value.trim();
-  let blocked = 0, reachable = 0, done = 0;
-
-  for (const r of visibleRows) {
-    const key = windowKey(r.checkinISO, r.nights);
-    const tr = document.querySelector(`tr[data-key="${cssEscape(key)}"]`);
-    const cell = tr ? tr.querySelector('[data-live]') : null;
-    if (cell) cell.textContent = 'checking…';
-
-    const link = buildLink(template, r.checkin, r.checkout);
-    const target = proxy ? proxy + encodeURIComponent(link) : link;
-    try {
-      // No-store, follow redirects. Most direct cross-site calls throw on CORS.
-      const res = await fetch(target, { method: 'GET', cache: 'no-store', redirect: 'follow' });
-      reachable++;
-      if (cell) cell.textContent = `reachable (HTTP ${res.status}) — open to confirm`;
-    } catch (err) {
-      blocked++;
-      if (cell) cell.textContent = 'blocked — use the Open link';
-    }
-    done++;
-    setLive(`Live check: ${done}/${visibleRows.length} · ${reachable} reachable · ${blocked} blocked`, 'warn');
-    await sleep(350); // be polite
-  }
-
-  liveRunning = false;
-  btn.disabled = false;
-  if (reachable === 0) {
-    setLive(`Live auto-check was blocked for all ${done} windows (expected — the site blocks cross-site reads). Use the “Open ↗” links and tick each status instead.`, 'warn');
-  } else {
-    setLive(`Live check done: ${reachable} reachable, ${blocked} blocked. Reachable doesn't confirm a free cottage — open the link to verify, then set the status.`, 'ok');
-  }
-}
-
-function cssEscape(s) {
-  return (window.CSS && CSS.escape) ? CSS.escape(s) : s.replace(/["\\]/g, '\\$&');
-}
-function sleep(ms) { return new Promise((res) => setTimeout(res, ms)); }
-function setLive(msg, cls) {
-  const el = $('live-status');
-  el.textContent = msg;
-  el.className = 'status-line' + (cls ? ' ' + cls : '');
-}
-
-/* ----------------------------- settings --------------------------- */
+/* --------------------------- settings I/O ------------------------- */
 
 function readSettings() {
   return {
     start: $('start-date').value,
     end: $('end-date').value,
     guests: Number($('guests').value) || 2,
-    lengths: selectedLengths(),
+    lengths: [...document.querySelectorAll('#length-chips input:checked')].map((el) => Number(el.value)).sort((a, b) => a - b),
     dow: $('dow-filter').value,
   };
 }
-
 function applySettings(s) {
   $('start-date').value = s.start;
   $('end-date').value = s.end;
   $('guests').value = s.guests;
   $('dow-filter').value = s.dow;
-  document.querySelectorAll('#length-chips input').forEach((el) => {
-    el.checked = s.lengths.includes(Number(el.value));
-  });
+  document.querySelectorAll('#length-chips input').forEach((el) => { el.checked = s.lengths.includes(Number(el.value)); });
 }
 
-function defaultSettings() {
-  // Default to "this summer" relative to today, falling back to 2026.
-  const now = new Date();
-  const year = now.getMonth() > 8 ? now.getFullYear() + 1 : now.getFullYear();
-  return {
-    start: `${year}-06-21`,
-    end: `${year}-09-07`,
-    guests: 2,
-    lengths: [2, 3, 4, 7],
-    dow: 'any',
-  };
+/* --------------------------- the calendar ------------------------- */
+// One cell per NIGHT, from earliest check-in to the night before latest
+// check-out (a checkout date is not itself a night you sleep there).
+
+function nightList() {
+  const start = dateFromISO(settings.start);
+  const lastNight = addDays(dateFromISO(settings.end), -1);
+  const out = [];
+  for (let d = new Date(start); d <= lastNight; d = addDays(d, 1)) out.push(new Date(d));
+  return out;
+}
+
+function nightState(iso) { return nights[iso] || 'unknown'; }
+
+function renderCalendar() {
+  const cal = $('calendar');
+  cal.innerHTML = '';
+  const all = nightList();
+  if (all.length === 0) return;
+
+  // Group nights by calendar month.
+  const byMonth = new Map();
+  for (const d of all) {
+    const key = `${d.getFullYear()}-${d.getMonth()}`;
+    if (!byMonth.has(key)) byMonth.set(key, []);
+    byMonth.get(key).push(d);
+  }
+
+  for (const [, days] of byMonth) {
+    const first = days[0];
+    const monthEl = document.createElement('div');
+    monthEl.className = 'month';
+
+    const checkLink = buildLink(first, addDays(days[days.length - 1], 1));
+    monthEl.innerHTML = `
+      <div class="month-head">
+        <h3>${MONTHS[first.getMonth()]} ${first.getFullYear()}</h3>
+        <a class="open-link" href="${checkLink}" target="_blank" rel="noopener">Open this month's calendar ↗</a>
+      </div>
+      <div class="dow-row">${WEEKDAYS.map((w) => `<span>${w[0]}</span>`).join('')}</div>`;
+
+    const grid = document.createElement('div');
+    grid.className = 'days';
+    // Leading blanks so the 1st lands under the right weekday.
+    for (let i = 0; i < first.getDay(); i++) {
+      const blank = document.createElement('span');
+      blank.className = 'day blank';
+      grid.appendChild(blank);
+    }
+    for (const d of days) {
+      const iso = toISO(d);
+      const cell = document.createElement('button');
+      cell.type = 'button';
+      cell.className = 'day ' + nightState(iso);
+      cell.dataset.iso = iso;
+      cell.textContent = d.getDate();
+      cell.title = prettyDate(d);
+      grid.appendChild(cell);
+    }
+    monthEl.appendChild(grid);
+    cal.appendChild(monthEl);
+  }
+}
+
+function cycleNight(iso) {
+  const cur = nightState(iso);
+  const next = cur === 'unknown' ? 'free' : cur === 'free' ? 'booked' : 'unknown';
+  if (next === 'unknown') delete nights[iso];
+  else nights[iso] = next;
+  save(STORE.nights, nights);
+}
+
+/* ----------------------- compute open stays ----------------------- */
+
+function dowAllowed(date, mode) {
+  const day = date.getDay();
+  if (mode === 'weekend') return day === 5 || day === 6;
+  if (mode === 'weekday') return day >= 0 && day <= 4;
+  return true;
+}
+
+// For every candidate check-in and accepted length, classify the window by the
+// state of its nights: 'open' (all free), 'blocked' (a booked night), or
+// 'partial' (no booked night, but some still unknown).
+function computeStays() {
+  const start = dateFromISO(settings.start);
+  const end = dateFromISO(settings.end);
+  const open = [], partial = [];
+
+  for (let d = new Date(start); d < end; d = addDays(d, 1)) {
+    if (!dowAllowed(d, settings.dow)) continue;
+    for (const n of settings.lengths) {
+      const checkout = addDays(d, n);
+      if (checkout > end) continue;
+      let booked = false, unknown = false;
+      for (let i = 0; i < n; i++) {
+        const st = nightState(toISO(addDays(d, i)));
+        if (st === 'booked') { booked = true; break; }
+        if (st === 'unknown') unknown = true;
+      }
+      if (booked) continue;
+      const stay = { checkin: new Date(d), checkout, nights: n };
+      (unknown ? partial : open).push(stay);
+    }
+  }
+  const byDate = (a, b) => a.checkin - b.checkin || a.nights - b.nights;
+  return { open: open.sort(byDate), partial: partial.sort(byDate) };
+}
+
+/* --------------------------- rendering ---------------------------- */
+
+function renderResults() {
+  const { open, partial } = computeStays();
+  const showPartial = $('show-partial').checked;
+  const rows = showPartial ? [...open.map((s) => ({ ...s, kind: 'open' })),
+                              ...partial.map((s) => ({ ...s, kind: 'partial' }))]
+                                .sort((a, b) => a.checkin - b.checkin || a.nights - b.nights)
+                           : open.map((s) => ({ ...s, kind: 'open' }));
+
+  const markedNights = Object.keys(nights).length;
+  $('summary-bar').innerHTML = `
+    <span class="pill open">${open.length} open stay${open.length === 1 ? '' : 's'}</span>
+    <span class="pill">${partial.length} possible (unchecked nights)</span>
+    <span class="pill">${markedNights} nights marked</span>`;
+
+  const body = $('results-body');
+  body.innerHTML = '';
+  if (rows.length === 0) {
+    body.innerHTML = `<tr><td colspan="5" class="empty">${
+      markedNights === 0
+        ? 'Mark some nights above (free / booked) and your open stays appear here.'
+        : 'No fully-open stays yet. Tick “show stays with unchecked nights,” or mark more nights as free.'
+    }</td></tr>`;
+    return;
+  }
+  for (const s of rows) {
+    const link = buildLink(s.checkin, s.checkout);
+    const tr = document.createElement('tr');
+    tr.dataset.kind = s.kind;
+    tr.innerHTML = `
+      <td>${prettyDate(s.checkin)} <small>${s.checkin.getFullYear()}</small></td>
+      <td>${prettyDate(s.checkout)} <small>${s.checkout.getFullYear()}</small></td>
+      <td>${s.nights}</td>
+      <td>${s.kind === 'open'
+            ? '<span class="tag tag-open">✅ Open</span>'
+            : '<span class="tag tag-partial">🤔 Check</span>'}</td>
+      <td><a class="open-link" href="${link}" target="_blank" rel="noopener">Book ↗</a></td>`;
+    body.appendChild(tr);
+  }
+}
+
+function refresh() {
+  renderCalendar();
+  renderResults();
+}
+
+/* --------------------------- template UI -------------------------- */
+
+function applyTemplateToUI() {
+  $('template-url').value = template.learned ? template.url : '';
+  const el = $('template-status');
+  if (template.learned) {
+    el.textContent = '✓ Using your learned link — Book links land on the right dates.';
+    el.className = 'status-line ok';
+  } else {
+    el.textContent = 'No link learned — Book links open the booking page for you to set dates.';
+    el.className = 'status-line';
+  }
+  const openBtn = $('open-booking');
+  if (openBtn) openBtn.href = template.url.includes('{CHECKIN}') ? BOOKING_BASE : template.url;
+}
+
+/* ------------------------------ actions --------------------------- */
+
+function build() {
+  const s = readSettings();
+  if (!s.start || !s.end) { alert('Set both an earliest check-in and a latest check-out date.'); return; }
+  if (dateFromISO(s.end) <= dateFromISO(s.start)) { alert('Latest check-out must be after earliest check-in.'); return; }
+  if (s.lengths.length === 0) { alert('Pick at least one stay length.'); return; }
+  settings = s;
+  save(STORE.settings, settings);
+  $('calendar-card').hidden = false;
+  $('results-card').hidden = false;
+  refresh();
+  $('calendar-card').scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+function copyList() {
+  const { open } = computeStays();
+  if (open.length === 0) { return; }
+  const text = open.map((s) =>
+    `${prettyDate(s.checkin)} ${s.checkin.getFullYear()} → ${prettyDate(s.checkout)} (${s.nights} night${s.nights > 1 ? 's' : ''})`
+  ).join('\n');
+  navigator.clipboard.writeText(text).catch(() => {});
 }
 
 /* ------------------------------ wire up --------------------------- */
 
-function generate() {
-  const settings = readSettings();
-  if (!settings.start || !settings.end) {
-    alert('Please set both an earliest check-in and a latest check-out date.');
-    return;
-  }
-  if (dateFromISO(settings.end) <= dateFromISO(settings.start)) {
-    alert('The latest check-out must be after the earliest check-in.');
-    return;
-  }
-  if (settings.lengths.length === 0) {
-    alert('Pick at least one stay length.');
-    return;
-  }
-  save(STORE.settings, settings);
-
-  const { rows, truncated } = generateWindows(settings);
-  currentRows = rows;
-  $('results-card').hidden = false;
-  renderTable();
-  setLive(truncated
-    ? `Showing the first ${MAX_ROWS} windows — narrow your dates or stay lengths for fewer.`
-    : `${rows.length} stay windows built. Open each to check the cottage, then set its status — your ticks are saved automatically.`,
-    truncated ? 'warn' : 'ok');
-  $('results-card').scrollIntoView({ behavior: 'smooth', block: 'start' });
-}
-
-function applyTemplateToUI() {
-  $('template-url').value = template.learned ? template.url : '';
-  const statusEl = $('template-status');
-  if (template.learned) {
-    statusEl.textContent = '✓ Using your learned booking link — generated links will land on the right dates.';
-    statusEl.className = 'status-line ok';
-  } else {
-    statusEl.textContent = 'No link learned yet — links open the booking page so you set dates there.';
-    statusEl.className = 'status-line';
-  }
-}
-
 function init() {
-  applySettings(load(STORE.settings, defaultSettings()));
-  $('proxy-url').value = load(STORE.proxy, '');
+  applySettings(settings);
   applyTemplateToUI();
 
-  $('generate-btn').addEventListener('click', generate);
+  $('build-btn').addEventListener('click', build);
 
   $('reset-btn').addEventListener('click', () => {
-    if (!confirm('Reset all settings, the learned link, and every date status?')) return;
-    [STORE.settings, STORE.template, STORE.statuses, STORE.proxy].forEach((k) => localStorage.removeItem(k));
+    if (!confirm('Reset preferences, the learned link, and every marked night?')) return;
+    Object.values(STORE).forEach((k) => localStorage.removeItem(k));
     location.reload();
   });
 
   $('learn-btn').addEventListener('click', () => {
     const raw = $('template-url').value.trim();
-    const statusEl = $('template-status');
-    if (!raw) {
-      template = defaultTemplate();
-      save(STORE.template, template);
-      applyTemplateToUI();
-      return;
-    }
+    const el = $('template-status');
+    if (!raw) { template = defaultTemplate(); save(STORE.template, template); applyTemplateToUI(); return; }
     try {
       template = learnTemplate(raw);
       save(STORE.template, template);
-      statusEl.textContent = '✓ Got it! Learned the date format from your link. Rebuild or refresh the checklist to use it.';
-      statusEl.className = 'status-line ok';
-      if (currentRows.length) renderTable();
+      applyTemplateToUI();
+      if (!$('calendar-card').hidden) refresh();
     } catch (err) {
-      statusEl.textContent = '⚠ ' + err.message;
-      statusEl.className = 'status-line warn';
+      el.textContent = '⚠ ' + err.message;
+      el.className = 'status-line warn';
     }
   });
 
-  $('proxy-url').addEventListener('change', () => save(STORE.proxy, $('proxy-url').value.trim()));
-
-  // Delegated handlers for the results table.
-  $('results-body').addEventListener('change', (e) => {
-    const tr = e.target.closest('tr[data-key]');
-    if (!tr) return;
-    const key = tr.dataset.key;
-    if (e.target.matches('[data-status]')) {
-      setStatus(key, { status: e.target.value });
-      tr.dataset.status = e.target.value;
-      renderSummary();
-    } else if (e.target.matches('[data-note]')) {
-      setStatus(key, { note: e.target.value });
-    }
+  // Calendar clicks (delegated).
+  $('calendar').addEventListener('click', (e) => {
+    const cell = e.target.closest('.day[data-iso]');
+    if (!cell) return;
+    cycleNight(cell.dataset.iso);
+    cell.className = 'day ' + nightState(cell.dataset.iso);
+    renderResults();
   });
 
-  $('show-open-only').addEventListener('change', renderTable);
-  $('filter-status').addEventListener('change', renderTable);
-  $('check-all-btn').addEventListener('click', liveCheckAll);
+  $('rest-free-btn').addEventListener('click', () => {
+    for (const d of nightList()) { const iso = toISO(d); if (!nights[iso]) nights[iso] = 'free'; }
+    save(STORE.nights, nights);
+    refresh();
+  });
+
+  $('all-unknown-btn').addEventListener('click', () => {
+    if (!confirm('Clear every night mark?')) return;
+    nights = {};
+    save(STORE.nights, nights);
+    refresh();
+  });
+
+  $('show-partial').addEventListener('change', renderResults);
+  $('copy-btn').addEventListener('click', copyList);
   $('print-btn').addEventListener('click', () => window.print());
-  $('copy-open-btn').addEventListener('click', copyOpenDates);
 
-  // Keep the "open booking page" button using the learned base if present.
-  const openBtn = $('open-booking');
-  if (openBtn) openBtn.href = template.url.includes('{CHECKIN}') ? BOOKING_BASE : template.url;
-}
-
-function copyOpenDates() {
-  const open = currentRows.filter((r) => getStatus(windowKey(r.checkinISO, r.nights)).status === 'open');
-  if (open.length === 0) {
-    setLive('No dates marked “Open” yet — tick some first.', 'warn');
-    return;
+  // If the user had a calendar going, restore it on load.
+  if (Object.keys(nights).length > 0) {
+    $('calendar-card').hidden = false;
+    $('results-card').hidden = false;
+    refresh();
   }
-  const text = open.map((r) =>
-    `${prettyDate(r.checkin)} ${r.checkin.getFullYear()} → ${prettyDate(r.checkout)} (${r.nights} night${r.nights > 1 ? 's' : ''})`
-  ).join('\n');
-  navigator.clipboard.writeText(text).then(
-    () => setLive(`Copied ${open.length} open date window(s) to your clipboard.`, 'ok'),
-    () => setLive('Could not copy automatically — here they are:\n' + text, 'warn')
-  );
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/seashore-cottage-finder/script.js
+++ b/seashore-cottage-finder/script.js
@@ -1,0 +1,485 @@
+'use strict';
+
+/* ------------------------------------------------------------------ *
+ * Seashore Cottage Finder
+ * Scans a whole summer for open stay windows at Sun Retreats Seashore
+ * (Premium Cottage, 2 Bedroom) so you don't have to check the resort's
+ * date picker one date at a time.
+ *
+ * Everything runs in your browser. Settings, the learned booking link,
+ * and per-date statuses are saved to localStorage only.
+ * ------------------------------------------------------------------ */
+
+const BOOKING_BASE = 'https://www.sunoutdoors.com/book/checkavailability/236/nj/sun-retreats-seashore';
+
+const STORE = {
+  settings: 'scf.settings.v1',
+  template: 'scf.template.v1',
+  statuses: 'scf.statuses.v1',
+  proxy:    'scf.proxy.v1',
+};
+
+const MAX_ROWS = 600; // safety guard against runaway combinations
+
+/* ----------------------------- helpers ---------------------------- */
+
+const $ = (id) => document.getElementById(id);
+
+// Build a Date at local noon to dodge timezone/DST off-by-one issues.
+function dateFromISO(iso) {
+  const [y, m, d] = iso.split('-').map(Number);
+  return new Date(y, m - 1, d, 12, 0, 0, 0);
+}
+
+function toISO(date) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function addDays(date, n) {
+  const out = new Date(date);
+  out.setDate(out.getDate() + n);
+  return out;
+}
+
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+                'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function prettyDate(date) {
+  return `${WEEKDAYS[date.getDay()]} ${MONTHS[date.getMonth()]} ${date.getDate()}`;
+}
+
+function load(key, fallback) {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function save(key, value) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch { /* storage full or blocked — ignore */ }
+}
+
+function windowKey(checkinISO, nights) {
+  return `${checkinISO}|${nights}`;
+}
+
+/* --------------------------- date format -------------------------- */
+// Recognise date-like strings inside a pasted URL so we can swap them out.
+
+const DATE_PATTERNS = [
+  { name: 'iso', re: /^\d{4}-\d{2}-\d{2}$/, parse: (s) => dateFromISO(s),
+    fmt: (d) => toISO(d) },
+  { name: 'us', re: /^\d{1,2}\/\d{1,2}\/\d{4}$/,
+    parse: (s) => { const [m, d, y] = s.split('/').map(Number); return new Date(y, m - 1, d, 12); },
+    fmt: (d) => `${d.getMonth() + 1}/${d.getDate()}/${d.getFullYear()}` },
+];
+
+function detectDate(value) {
+  for (const p of DATE_PATTERNS) {
+    if (p.re.test(value)) {
+      const dt = p.parse(value);
+      if (!isNaN(dt)) return { pattern: p, date: dt };
+    }
+  }
+  return null;
+}
+
+/* --------------------------- templates ---------------------------- */
+// A template is the booking URL with {CHECKIN}/{CHECKOUT} placeholders,
+// plus the date format to render them in.
+
+function defaultTemplate() {
+  // No guessed date params: a bare link is guaranteed to open the page.
+  return { url: BOOKING_BASE, format: 'iso', learned: false };
+}
+
+function learnTemplate(rawUrl) {
+  const url = new URL(rawUrl.trim());
+  const found = [];
+  for (const [k, v] of url.searchParams.entries()) {
+    const hit = detectDate(v);
+    if (hit) found.push({ key: k, ...hit });
+  }
+  if (found.length < 2) {
+    throw new Error('Could not find two dates in that URL. Make sure you picked dates on the booking page before copying the link.');
+  }
+  // Earliest date = check-in, latest = check-out.
+  found.sort((a, b) => a.date - b.date);
+  const checkinHit = found[0];
+  const checkoutHit = found[found.length - 1];
+
+  url.searchParams.set(checkinHit.key, '{CHECKIN}');
+  url.searchParams.set(checkoutHit.key, '{CHECKOUT}');
+
+  // decodeURIComponent so our placeholders stay readable in the stored string.
+  const templateUrl = decodeURIComponent(url.toString());
+  return { url: templateUrl, format: checkinHit.pattern.name, learned: true };
+}
+
+function buildLink(template, checkin, checkout) {
+  const fmt = DATE_PATTERNS.find((p) => p.name === template.format) || DATE_PATTERNS[0];
+  if (!template.url.includes('{CHECKIN}')) {
+    return template.url; // bare booking page
+  }
+  return template.url
+    .replace('{CHECKIN}', encodeURIComponent(fmt.fmt(checkin)))
+    .replace('{CHECKOUT}', encodeURIComponent(fmt.fmt(checkout)));
+}
+
+/* --------------------------- generation --------------------------- */
+
+function selectedLengths() {
+  return [...document.querySelectorAll('#length-chips input:checked')]
+    .map((el) => Number(el.value))
+    .sort((a, b) => a - b);
+}
+
+function dowAllowed(date, mode) {
+  const day = date.getDay(); // 0 Sun .. 6 Sat
+  if (mode === 'weekend') return day === 5 || day === 6;
+  if (mode === 'weekday') return day >= 0 && day <= 4;
+  return true;
+}
+
+function generateWindows(settings) {
+  const start = dateFromISO(settings.start);
+  const end = dateFromISO(settings.end);
+  const lengths = settings.lengths;
+  const rows = [];
+
+  for (let d = new Date(start); d <= end; d = addDays(d, 1)) {
+    if (!dowAllowed(d, settings.dow)) continue;
+    for (const nights of lengths) {
+      const checkout = addDays(d, nights);
+      if (checkout > end) continue;
+      rows.push({
+        checkin: new Date(d),
+        checkout,
+        checkinISO: toISO(d),
+        checkoutISO: toISO(checkout),
+        nights,
+      });
+      if (rows.length > MAX_ROWS) return { rows, truncated: true };
+    }
+  }
+  rows.sort((a, b) => a.checkin - b.checkin || a.nights - b.nights);
+  return { rows, truncated: false };
+}
+
+/* ----------------------------- state ------------------------------ */
+
+let currentRows = [];
+let template = load(STORE.template, defaultTemplate());
+let statuses = load(STORE.statuses, {});   // windowKey -> { status, note }
+
+/* --------------------------- rendering ---------------------------- */
+
+const STATUS_LABELS = {
+  unknown: 'Not checked',
+  open: '✅ Open',
+  full: '❌ Full',
+  maybe: '🤔 Maybe',
+};
+
+function getStatus(key) {
+  return statuses[key] || { status: 'unknown', note: '' };
+}
+
+function setStatus(key, patch) {
+  statuses[key] = { ...getStatus(key), ...patch };
+  save(STORE.statuses, statuses);
+}
+
+function rowVisible(key) {
+  const openOnly = $('show-open-only').checked;
+  const filter = $('filter-status').value;
+  const st = getStatus(key).status;
+  if (openOnly && st !== 'open') return false;
+  if (filter !== 'all' && st !== filter) return false;
+  return true;
+}
+
+function renderSummary() {
+  const counts = { total: currentRows.length, open: 0, full: 0, maybe: 0, unknown: 0 };
+  for (const r of currentRows) counts[getStatus(windowKey(r.checkinISO, r.nights)).status]++;
+  $('summary-bar').innerHTML = `
+    <span class="pill">${counts.total} windows</span>
+    <span class="pill open">${counts.open} open</span>
+    <span class="pill">${counts.maybe} maybe</span>
+    <span class="pill full">${counts.full} full</span>
+    <span class="pill">${counts.unknown} unchecked</span>`;
+}
+
+function renderTable() {
+  const body = $('results-body');
+  body.innerHTML = '';
+  let shown = 0;
+
+  for (const r of currentRows) {
+    const key = windowKey(r.checkinISO, r.nights);
+    if (!rowVisible(key)) continue;
+    shown++;
+    const st = getStatus(key);
+    const link = buildLink(template, r.checkin, r.checkout);
+
+    const tr = document.createElement('tr');
+    tr.dataset.status = st.status;
+    tr.dataset.key = key;
+
+    tr.innerHTML = `
+      <td>${prettyDate(r.checkin)}<br><small>${r.checkin.getFullYear()}</small></td>
+      <td>${prettyDate(r.checkout)}<br><small>${r.checkout.getFullYear()}</small></td>
+      <td>${r.nights}</td>
+      <td><a class="open-link" href="${link}" target="_blank" rel="noopener">Open ↗</a>
+          <div class="live-cell" data-live></div></td>
+      <td>
+        <select data-status>
+          <option value="unknown">Not checked</option>
+          <option value="open">✅ Open</option>
+          <option value="full">❌ Full</option>
+          <option value="maybe">🤔 Maybe</option>
+        </select>
+      </td>
+      <td><input class="note-input" type="text" data-note placeholder="notes…" value="${escapeAttr(st.note)}"></td>`;
+
+    tr.querySelector('[data-status]').value = st.status;
+    body.appendChild(tr);
+  }
+
+  if (shown === 0) {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td colspan="6" style="text-align:center;color:var(--text-muted);padding:24px;">No windows match this filter.</td>`;
+    body.appendChild(tr);
+  }
+  renderSummary();
+}
+
+function escapeAttr(s) {
+  return String(s || '').replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+}
+
+/* ----------------------------- live check ------------------------- */
+
+let liveRunning = false;
+
+async function liveCheckAll() {
+  if (liveRunning) return;
+  const visibleRows = currentRows.filter((r) => rowVisible(windowKey(r.checkinISO, r.nights)));
+  if (visibleRows.length === 0) return;
+
+  if (!template.learned) {
+    if (!confirm('You haven\'t taught the tool your booking link yet, so the live check can only reach the generic booking page (no dates). It will likely be blocked by the site\'s security. Continue anyway?')) return;
+  }
+  if (visibleRows.length > 60 &&
+      !confirm(`This will attempt ${visibleRows.length} live requests, one at a time. That can take a while and may get blocked. Continue?`)) {
+    return;
+  }
+
+  liveRunning = true;
+  const btn = $('check-all-btn');
+  btn.disabled = true;
+  const proxy = $('proxy-url').value.trim();
+  let blocked = 0, reachable = 0, done = 0;
+
+  for (const r of visibleRows) {
+    const key = windowKey(r.checkinISO, r.nights);
+    const tr = document.querySelector(`tr[data-key="${cssEscape(key)}"]`);
+    const cell = tr ? tr.querySelector('[data-live]') : null;
+    if (cell) cell.textContent = 'checking…';
+
+    const link = buildLink(template, r.checkin, r.checkout);
+    const target = proxy ? proxy + encodeURIComponent(link) : link;
+    try {
+      // No-store, follow redirects. Most direct cross-site calls throw on CORS.
+      const res = await fetch(target, { method: 'GET', cache: 'no-store', redirect: 'follow' });
+      reachable++;
+      if (cell) cell.textContent = `reachable (HTTP ${res.status}) — open to confirm`;
+    } catch (err) {
+      blocked++;
+      if (cell) cell.textContent = 'blocked — use the Open link';
+    }
+    done++;
+    setLive(`Live check: ${done}/${visibleRows.length} · ${reachable} reachable · ${blocked} blocked`, 'warn');
+    await sleep(350); // be polite
+  }
+
+  liveRunning = false;
+  btn.disabled = false;
+  if (reachable === 0) {
+    setLive(`Live auto-check was blocked for all ${done} windows (expected — the site blocks cross-site reads). Use the “Open ↗” links and tick each status instead.`, 'warn');
+  } else {
+    setLive(`Live check done: ${reachable} reachable, ${blocked} blocked. Reachable doesn't confirm a free cottage — open the link to verify, then set the status.`, 'ok');
+  }
+}
+
+function cssEscape(s) {
+  return (window.CSS && CSS.escape) ? CSS.escape(s) : s.replace(/["\\]/g, '\\$&');
+}
+function sleep(ms) { return new Promise((res) => setTimeout(res, ms)); }
+function setLive(msg, cls) {
+  const el = $('live-status');
+  el.textContent = msg;
+  el.className = 'status-line' + (cls ? ' ' + cls : '');
+}
+
+/* ----------------------------- settings --------------------------- */
+
+function readSettings() {
+  return {
+    start: $('start-date').value,
+    end: $('end-date').value,
+    guests: Number($('guests').value) || 2,
+    lengths: selectedLengths(),
+    dow: $('dow-filter').value,
+  };
+}
+
+function applySettings(s) {
+  $('start-date').value = s.start;
+  $('end-date').value = s.end;
+  $('guests').value = s.guests;
+  $('dow-filter').value = s.dow;
+  document.querySelectorAll('#length-chips input').forEach((el) => {
+    el.checked = s.lengths.includes(Number(el.value));
+  });
+}
+
+function defaultSettings() {
+  // Default to "this summer" relative to today, falling back to 2026.
+  const now = new Date();
+  const year = now.getMonth() > 8 ? now.getFullYear() + 1 : now.getFullYear();
+  return {
+    start: `${year}-06-21`,
+    end: `${year}-09-07`,
+    guests: 2,
+    lengths: [2, 3, 4, 7],
+    dow: 'any',
+  };
+}
+
+/* ------------------------------ wire up --------------------------- */
+
+function generate() {
+  const settings = readSettings();
+  if (!settings.start || !settings.end) {
+    alert('Please set both an earliest check-in and a latest check-out date.');
+    return;
+  }
+  if (dateFromISO(settings.end) <= dateFromISO(settings.start)) {
+    alert('The latest check-out must be after the earliest check-in.');
+    return;
+  }
+  if (settings.lengths.length === 0) {
+    alert('Pick at least one stay length.');
+    return;
+  }
+  save(STORE.settings, settings);
+
+  const { rows, truncated } = generateWindows(settings);
+  currentRows = rows;
+  $('results-card').hidden = false;
+  renderTable();
+  setLive(truncated
+    ? `Showing the first ${MAX_ROWS} windows — narrow your dates or stay lengths for fewer.`
+    : `${rows.length} stay windows built. Open each to check the cottage, then set its status — your ticks are saved automatically.`,
+    truncated ? 'warn' : 'ok');
+  $('results-card').scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+function applyTemplateToUI() {
+  $('template-url').value = template.learned ? template.url : '';
+  const statusEl = $('template-status');
+  if (template.learned) {
+    statusEl.textContent = '✓ Using your learned booking link — generated links will land on the right dates.';
+    statusEl.className = 'status-line ok';
+  } else {
+    statusEl.textContent = 'No link learned yet — links open the booking page so you set dates there.';
+    statusEl.className = 'status-line';
+  }
+}
+
+function init() {
+  applySettings(load(STORE.settings, defaultSettings()));
+  $('proxy-url').value = load(STORE.proxy, '');
+  applyTemplateToUI();
+
+  $('generate-btn').addEventListener('click', generate);
+
+  $('reset-btn').addEventListener('click', () => {
+    if (!confirm('Reset all settings, the learned link, and every date status?')) return;
+    [STORE.settings, STORE.template, STORE.statuses, STORE.proxy].forEach((k) => localStorage.removeItem(k));
+    location.reload();
+  });
+
+  $('learn-btn').addEventListener('click', () => {
+    const raw = $('template-url').value.trim();
+    const statusEl = $('template-status');
+    if (!raw) {
+      template = defaultTemplate();
+      save(STORE.template, template);
+      applyTemplateToUI();
+      return;
+    }
+    try {
+      template = learnTemplate(raw);
+      save(STORE.template, template);
+      statusEl.textContent = '✓ Got it! Learned the date format from your link. Rebuild or refresh the checklist to use it.';
+      statusEl.className = 'status-line ok';
+      if (currentRows.length) renderTable();
+    } catch (err) {
+      statusEl.textContent = '⚠ ' + err.message;
+      statusEl.className = 'status-line warn';
+    }
+  });
+
+  $('proxy-url').addEventListener('change', () => save(STORE.proxy, $('proxy-url').value.trim()));
+
+  // Delegated handlers for the results table.
+  $('results-body').addEventListener('change', (e) => {
+    const tr = e.target.closest('tr[data-key]');
+    if (!tr) return;
+    const key = tr.dataset.key;
+    if (e.target.matches('[data-status]')) {
+      setStatus(key, { status: e.target.value });
+      tr.dataset.status = e.target.value;
+      renderSummary();
+    } else if (e.target.matches('[data-note]')) {
+      setStatus(key, { note: e.target.value });
+    }
+  });
+
+  $('show-open-only').addEventListener('change', renderTable);
+  $('filter-status').addEventListener('change', renderTable);
+  $('check-all-btn').addEventListener('click', liveCheckAll);
+  $('print-btn').addEventListener('click', () => window.print());
+  $('copy-open-btn').addEventListener('click', copyOpenDates);
+
+  // Keep the "open booking page" button using the learned base if present.
+  const openBtn = $('open-booking');
+  if (openBtn) openBtn.href = template.url.includes('{CHECKIN}') ? BOOKING_BASE : template.url;
+}
+
+function copyOpenDates() {
+  const open = currentRows.filter((r) => getStatus(windowKey(r.checkinISO, r.nights)).status === 'open');
+  if (open.length === 0) {
+    setLive('No dates marked “Open” yet — tick some first.', 'warn');
+    return;
+  }
+  const text = open.map((r) =>
+    `${prettyDate(r.checkin)} ${r.checkin.getFullYear()} → ${prettyDate(r.checkout)} (${r.nights} night${r.nights > 1 ? 's' : ''})`
+  ).join('\n');
+  navigator.clipboard.writeText(text).then(
+    () => setLive(`Copied ${open.length} open date window(s) to your clipboard.`, 'ok'),
+    () => setLive('Could not copy automatically — here they are:\n' + text, 'warn')
+  );
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/seashore-cottage-finder/script.js
+++ b/seashore-cottage-finder/script.js
@@ -1,128 +1,54 @@
 'use strict';
 
 /* ------------------------------------------------------------------ *
- * Seashore Cottage Finder
+ * Seashore Cottage Finder — page controller
  *
- * Key idea: availability is PER NIGHT, not per stay window. The resort's
- * booking calendar greys out booked nights a whole month at a time. So you
- * mark the booked nights once (a handful of clicks), and this tool computes
- * EVERY open stay window that fits your trip length — instead of you clicking
- * through hundreds of date combinations.
+ * Two jobs:
+ *  1. Generate a configured copy of auto-check.js (the in-browser
+ *     automation) plus a bookmarklet, from the user's preferences.
+ *  2. Provide a manual night-calendar fallback that computes open stays
+ *     from nights the user marks by hand.
  *
- * Everything runs in your browser. Preferences, the learned booking link, and
- * the nights you mark are saved to localStorage only.
+ * Settings and marked nights persist in localStorage only.
  * ------------------------------------------------------------------ */
 
 const BOOKING_BASE = 'https://www.sunoutdoors.com/book/checkavailability/236/nj/sun-retreats-seashore';
-
-const STORE = {
-  settings: 'scf.settings.v2',
-  template: 'scf.template.v2',
-  nights:   'scf.nights.v2',   // 'YYYY-MM-DD' -> 'free' | 'booked'  (absent = unknown)
-};
-
-/* ----------------------------- helpers ---------------------------- */
+const STORE = { settings: 'scf.settings.v3', nights: 'scf.nights.v3' };
 
 const $ = (id) => document.getElementById(id);
 
-function dateFromISO(iso) {
-  const [y, m, d] = iso.split('-').map(Number);
-  return new Date(y, m - 1, d, 12, 0, 0, 0);
-}
-function toISO(date) {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, '0');
-  const d = String(date.getDate()).padStart(2, '0');
-  return `${y}-${m}-${d}`;
-}
-function addDays(date, n) {
-  const out = new Date(date);
-  out.setDate(out.getDate() + n);
-  return out;
-}
+/* ----------------------------- dates ------------------------------ */
+function dateFromISO(s) { const [y, m, d] = s.split('-').map(Number); return new Date(y, m - 1, d, 12); }
+function toISO(d) { return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0'); }
+function addDays(d, n) { const o = new Date(d); o.setDate(o.getDate() + n); return o; }
+const WD = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const MON = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+const MA = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+function pretty(d) { return `${WD[d.getDay()]} ${MA[d.getMonth()]} ${d.getDate()}`; }
 
-const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June',
-                'July', 'August', 'September', 'October', 'November', 'December'];
-const MON_ABBR = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-
-function prettyDate(date) {
-  return `${WEEKDAYS[date.getDay()]} ${MON_ABBR[date.getMonth()]} ${date.getDate()}`;
-}
-
-function load(key, fallback) {
-  try { const raw = localStorage.getItem(key); return raw ? JSON.parse(raw) : fallback; }
-  catch { return fallback; }
-}
-function save(key, value) {
-  try { localStorage.setItem(key, JSON.stringify(value)); } catch { /* ignore */ }
-}
-
-/* --------------------------- date format -------------------------- */
-// Recognise date-like strings in a pasted URL so we can templatise them.
-
-const DATE_PATTERNS = [
-  { name: 'iso', re: /^\d{4}-\d{2}-\d{2}$/, parse: (s) => dateFromISO(s), fmt: (d) => toISO(d) },
-  { name: 'us', re: /^\d{1,2}\/\d{1,2}\/\d{4}$/,
-    parse: (s) => { const [m, d, y] = s.split('/').map(Number); return new Date(y, m - 1, d, 12); },
-    fmt: (d) => `${d.getMonth() + 1}/${d.getDate()}/${d.getFullYear()}` },
-];
-function detectDate(value) {
-  for (const p of DATE_PATTERNS) {
-    if (p.re.test(value)) { const dt = p.parse(value); if (!isNaN(dt)) return { pattern: p, date: dt }; }
-  }
-  return null;
-}
-
-/* --------------------------- templates ---------------------------- */
-
-function defaultTemplate() { return { url: BOOKING_BASE, format: 'iso', learned: false }; }
-
-function learnTemplate(rawUrl) {
-  const url = new URL(rawUrl.trim());
-  const found = [];
-  for (const [k, v] of url.searchParams.entries()) {
-    const hit = detectDate(v);
-    if (hit) found.push({ key: k, ...hit });
-  }
-  if (found.length < 2) {
-    throw new Error('Could not find two dates in that URL. Pick dates on the booking page first, then copy the link.');
-  }
-  found.sort((a, b) => a.date - b.date);
-  url.searchParams.set(found[0].key, '{CHECKIN}');
-  url.searchParams.set(found[found.length - 1].key, '{CHECKOUT}');
-  return { url: decodeURIComponent(url.toString()), format: found[0].pattern.name, learned: true };
-}
-
-function buildLink(checkin, checkout) {
-  if (!template.url.includes('{CHECKIN}')) return template.url;
-  const fmt = DATE_PATTERNS.find((p) => p.name === template.format) || DATE_PATTERNS[0];
-  return template.url
-    .replace('{CHECKIN}', encodeURIComponent(fmt.fmt(checkin)))
-    .replace('{CHECKOUT}', encodeURIComponent(fmt.fmt(checkout)));
-}
+function load(k, f) { try { const r = localStorage.getItem(k); return r ? JSON.parse(r) : f; } catch { return f; } }
+function save(k, v) { try { localStorage.setItem(k, JSON.stringify(v)); } catch {} }
 
 /* ----------------------------- state ------------------------------ */
-
-let settings = load(STORE.settings, defaultSettings());
-let template = load(STORE.template, defaultTemplate());
-let nights = load(STORE.nights, {});   // ISO -> 'free' | 'booked'
-
 function defaultSettings() {
   const now = new Date();
   const year = now.getMonth() > 8 ? now.getFullYear() + 1 : now.getFullYear();
-  return { start: `${year}-06-21`, end: `${year}-09-07`, guests: 2, lengths: [2, 3, 4, 7], dow: 'any' };
+  return { start: `${year}-06-21`, end: `${year}-09-07`, guests: 2, lengths: [2, 3, 4, 7], dow: 'any', keyword: 'Premium Cottage', throttle: 450 };
 }
+let settings = load(STORE.settings, defaultSettings());
+let nights = load(STORE.nights, {});
+let autoTemplate = '';   // raw auto-check.js text with markers
 
 /* --------------------------- settings I/O ------------------------- */
-
 function readSettings() {
   return {
     start: $('start-date').value,
     end: $('end-date').value,
     guests: Number($('guests').value) || 2,
-    lengths: [...document.querySelectorAll('#length-chips input:checked')].map((el) => Number(el.value)).sort((a, b) => a - b),
+    lengths: [...document.querySelectorAll('#length-chips input:checked')].map((e) => Number(e.value)).sort((a, b) => a - b),
     dow: $('dow-filter').value,
+    keyword: $('unit-keyword').value.trim() || 'Premium Cottage',
+    throttle: Math.max(150, Number($('throttle').value) || 450),
   };
 }
 function applySettings(s) {
@@ -130,266 +56,141 @@ function applySettings(s) {
   $('end-date').value = s.end;
   $('guests').value = s.guests;
   $('dow-filter').value = s.dow;
-  document.querySelectorAll('#length-chips input').forEach((el) => { el.checked = s.lengths.includes(Number(el.value)); });
+  $('unit-keyword').value = s.keyword;
+  $('throttle').value = s.throttle;
+  document.querySelectorAll('#length-chips input').forEach((e) => { e.checked = s.lengths.includes(Number(e.value)); });
 }
 
-/* --------------------------- the calendar ------------------------- */
-// One cell per NIGHT, from earliest check-in to the night before latest
-// check-out (a checkout date is not itself a night you sleep there).
+/* ----------------------- generate the checker --------------------- */
+function configBlock(s) {
+  return '/*__CONFIG__*/\n  var CONFIG = ' + JSON.stringify({
+    start: s.start, end: s.end, lengths: s.lengths, dow: s.dow,
+    unitKeyword: s.keyword, throttleMs: s.throttle,
+  }, null, 2).replace(/\n/g, '\n  ') + ';\n  /*__END_CONFIG__*/';
+}
 
+function generatedScript() {
+  if (!autoTemplate) return '';
+  const s = readSettings();
+  return autoTemplate.replace(/\/\*__CONFIG__\*\/[\s\S]*?\/\*__END_CONFIG__\*\//, configBlock(s));
+}
+
+function refreshGenerated() {
+  const code = generatedScript();
+  $('script-preview').value = code || '// Could not load auto-check.js — use “Copy the checker script” after the page fully loads.';
+  if (code) {
+    $('bookmarklet').href = 'javascript:' + encodeURIComponent(code);
+  }
+}
+
+/* ----------------------- manual calendar -------------------------- */
 function nightList() {
-  const start = dateFromISO(settings.start);
-  const lastNight = addDays(dateFromISO(settings.end), -1);
-  const out = [];
+  const start = dateFromISO(settings.start), lastNight = addDays(dateFromISO(settings.end), -1), out = [];
   for (let d = new Date(start); d <= lastNight; d = addDays(d, 1)) out.push(new Date(d));
   return out;
 }
-
 function nightState(iso) { return nights[iso] || 'unknown'; }
 
 function renderCalendar() {
-  const cal = $('calendar');
-  cal.innerHTML = '';
-  const all = nightList();
-  if (all.length === 0) return;
-
-  // Group nights by calendar month.
+  const cal = $('calendar'); cal.innerHTML = '';
+  const all = nightList(); if (!all.length) return;
   const byMonth = new Map();
-  for (const d of all) {
-    const key = `${d.getFullYear()}-${d.getMonth()}`;
-    if (!byMonth.has(key)) byMonth.set(key, []);
-    byMonth.get(key).push(d);
-  }
-
+  for (const d of all) { const k = `${d.getFullYear()}-${d.getMonth()}`; (byMonth.get(k) || byMonth.set(k, []).get(k)).push(d); }
   for (const [, days] of byMonth) {
-    const first = days[0];
-    const monthEl = document.createElement('div');
-    monthEl.className = 'month';
-
-    const checkLink = buildLink(first, addDays(days[days.length - 1], 1));
-    monthEl.innerHTML = `
-      <div class="month-head">
-        <h3>${MONTHS[first.getMonth()]} ${first.getFullYear()}</h3>
-        <a class="open-link" href="${checkLink}" target="_blank" rel="noopener">Open this month's calendar ↗</a>
-      </div>
-      <div class="dow-row">${WEEKDAYS.map((w) => `<span>${w[0]}</span>`).join('')}</div>`;
-
-    const grid = document.createElement('div');
-    grid.className = 'days';
-    // Leading blanks so the 1st lands under the right weekday.
-    for (let i = 0; i < first.getDay(); i++) {
-      const blank = document.createElement('span');
-      blank.className = 'day blank';
-      grid.appendChild(blank);
-    }
+    const first = days[0], monthEl = document.createElement('div'); monthEl.className = 'month';
+    monthEl.innerHTML = `<div class="month-head"><h3>${MON[first.getMonth()]} ${first.getFullYear()}</h3></div>
+      <div class="dow-row">${WD.map((w) => `<span>${w[0]}</span>`).join('')}</div>`;
+    const grid = document.createElement('div'); grid.className = 'days';
+    for (let i = 0; i < first.getDay(); i++) { const b = document.createElement('span'); b.className = 'day blank'; grid.appendChild(b); }
     for (const d of days) {
-      const iso = toISO(d);
-      const cell = document.createElement('button');
-      cell.type = 'button';
-      cell.className = 'day ' + nightState(iso);
-      cell.dataset.iso = iso;
-      cell.textContent = d.getDate();
-      cell.title = prettyDate(d);
+      const iso = toISO(d), cell = document.createElement('button');
+      cell.type = 'button'; cell.className = 'day ' + nightState(iso); cell.dataset.iso = iso; cell.textContent = d.getDate(); cell.title = pretty(d);
       grid.appendChild(cell);
     }
-    monthEl.appendChild(grid);
-    cal.appendChild(monthEl);
+    monthEl.appendChild(grid); cal.appendChild(monthEl);
   }
 }
-
 function cycleNight(iso) {
-  const cur = nightState(iso);
-  const next = cur === 'unknown' ? 'free' : cur === 'free' ? 'booked' : 'unknown';
-  if (next === 'unknown') delete nights[iso];
-  else nights[iso] = next;
+  const cur = nightState(iso), next = cur === 'unknown' ? 'free' : cur === 'free' ? 'booked' : 'unknown';
+  if (next === 'unknown') delete nights[iso]; else nights[iso] = next;
   save(STORE.nights, nights);
 }
-
-/* ----------------------- compute open stays ----------------------- */
-
-function dowAllowed(date, mode) {
-  const day = date.getDay();
-  if (mode === 'weekend') return day === 5 || day === 6;
-  if (mode === 'weekday') return day >= 0 && day <= 4;
-  return true;
-}
-
-// For every candidate check-in and accepted length, classify the window by the
-// state of its nights: 'open' (all free), 'blocked' (a booked night), or
-// 'partial' (no booked night, but some still unknown).
-function computeStays() {
-  const start = dateFromISO(settings.start);
-  const end = dateFromISO(settings.end);
-  const open = [], partial = [];
-
+function dowAllowed(d) { const k = d.getDay(); if (settings.dow === 'weekend') return k === 5 || k === 6; if (settings.dow === 'weekday') return k <= 4; return true; }
+function computeOpen() {
+  const start = dateFromISO(settings.start), end = dateFromISO(settings.end), open = [], partial = [];
   for (let d = new Date(start); d < end; d = addDays(d, 1)) {
-    if (!dowAllowed(d, settings.dow)) continue;
+    if (!dowAllowed(d)) continue;
     for (const n of settings.lengths) {
-      const checkout = addDays(d, n);
-      if (checkout > end) continue;
+      const co = addDays(d, n); if (co > end) continue;
       let booked = false, unknown = false;
-      for (let i = 0; i < n; i++) {
-        const st = nightState(toISO(addDays(d, i)));
-        if (st === 'booked') { booked = true; break; }
-        if (st === 'unknown') unknown = true;
-      }
+      for (let i = 0; i < n; i++) { const st = nightState(toISO(addDays(d, i))); if (st === 'booked') { booked = true; break; } if (st === 'unknown') unknown = true; }
       if (booked) continue;
-      const stay = { checkin: new Date(d), checkout, nights: n };
-      (unknown ? partial : open).push(stay);
+      (unknown ? partial : open).push({ ci: new Date(d), co, n });
     }
   }
-  const byDate = (a, b) => a.checkin - b.checkin || a.nights - b.nights;
-  return { open: open.sort(byDate), partial: partial.sort(byDate) };
+  return { open, partial };
 }
-
-/* --------------------------- rendering ---------------------------- */
-
 function renderResults() {
-  const { open, partial } = computeStays();
-  const showPartial = $('show-partial').checked;
-  const rows = showPartial ? [...open.map((s) => ({ ...s, kind: 'open' })),
-                              ...partial.map((s) => ({ ...s, kind: 'partial' }))]
-                                .sort((a, b) => a.checkin - b.checkin || a.nights - b.nights)
-                           : open.map((s) => ({ ...s, kind: 'open' }));
-
-  const markedNights = Object.keys(nights).length;
-  $('summary-bar').innerHTML = `
-    <span class="pill open">${open.length} open stay${open.length === 1 ? '' : 's'}</span>
-    <span class="pill">${partial.length} possible (unchecked nights)</span>
-    <span class="pill">${markedNights} nights marked</span>`;
-
-  const body = $('results-body');
-  body.innerHTML = '';
-  if (rows.length === 0) {
-    body.innerHTML = `<tr><td colspan="5" class="empty">${
-      markedNights === 0
-        ? 'Mark some nights above (free / booked) and your open stays appear here.'
-        : 'No fully-open stays yet. Tick “show stays with unchecked nights,” or mark more nights as free.'
-    }</td></tr>`;
-    return;
-  }
-  for (const s of rows) {
-    const link = buildLink(s.checkin, s.checkout);
+  const { open, partial } = computeOpen();
+  $('summary-bar').innerHTML = `<span class="pill open">${open.length} open</span><span class="pill">${partial.length} possible</span><span class="pill">${Object.keys(nights).length} nights marked</span>`;
+  const body = $('results-body'); body.innerHTML = '';
+  const rows = open.map((s) => ({ ...s, k: 'open' }));
+  if (!rows.length) { body.innerHTML = `<tr><td colspan="5" class="empty">Mark some nights above to see open stays.</td></tr>`; return; }
+  for (const s of rows.sort((a, b) => a.ci - b.ci || a.n - b.n)) {
     const tr = document.createElement('tr');
-    tr.dataset.kind = s.kind;
-    tr.innerHTML = `
-      <td>${prettyDate(s.checkin)} <small>${s.checkin.getFullYear()}</small></td>
-      <td>${prettyDate(s.checkout)} <small>${s.checkout.getFullYear()}</small></td>
-      <td>${s.nights}</td>
-      <td>${s.kind === 'open'
-            ? '<span class="tag tag-open">✅ Open</span>'
-            : '<span class="tag tag-partial">🤔 Check</span>'}</td>
-      <td><a class="open-link" href="${link}" target="_blank" rel="noopener">Book ↗</a></td>`;
+    tr.innerHTML = `<td>${pretty(s.ci)} <small>${s.ci.getFullYear()}</small></td><td>${pretty(s.co)}</td><td>${s.n}</td>
+      <td><span class="tag tag-open">✅ Open</span></td>
+      <td><a class="open-link" href="${BOOKING_BASE}" target="_blank" rel="noopener">Book ↗</a></td>`;
     body.appendChild(tr);
   }
 }
-
-function refresh() {
-  renderCalendar();
-  renderResults();
-}
-
-/* --------------------------- template UI -------------------------- */
-
-function applyTemplateToUI() {
-  $('template-url').value = template.learned ? template.url : '';
-  const el = $('template-status');
-  if (template.learned) {
-    el.textContent = '✓ Using your learned link — Book links land on the right dates.';
-    el.className = 'status-line ok';
-  } else {
-    el.textContent = 'No link learned — Book links open the booking page for you to set dates.';
-    el.className = 'status-line';
-  }
-  const openBtn = $('open-booking');
-  if (openBtn) openBtn.href = template.url.includes('{CHECKIN}') ? BOOKING_BASE : template.url;
-}
-
-/* ------------------------------ actions --------------------------- */
-
-function build() {
-  const s = readSettings();
-  if (!s.start || !s.end) { alert('Set both an earliest check-in and a latest check-out date.'); return; }
-  if (dateFromISO(s.end) <= dateFromISO(s.start)) { alert('Latest check-out must be after earliest check-in.'); return; }
-  if (s.lengths.length === 0) { alert('Pick at least one stay length.'); return; }
-  settings = s;
-  save(STORE.settings, settings);
-  $('calendar-card').hidden = false;
-  $('results-card').hidden = false;
-  refresh();
-  $('calendar-card').scrollIntoView({ behavior: 'smooth', block: 'start' });
-}
-
-function copyList() {
-  const { open } = computeStays();
-  if (open.length === 0) { return; }
-  const text = open.map((s) =>
-    `${prettyDate(s.checkin)} ${s.checkin.getFullYear()} → ${prettyDate(s.checkout)} (${s.nights} night${s.nights > 1 ? 's' : ''})`
-  ).join('\n');
-  navigator.clipboard.writeText(text).catch(() => {});
-}
+function refreshManual() { renderCalendar(); renderResults(); }
 
 /* ------------------------------ wire up --------------------------- */
-
 function init() {
   applySettings(settings);
-  applyTemplateToUI();
 
-  $('build-btn').addEventListener('click', build);
+  // Load the automation script template (same-origin on the deployed site).
+  fetch('auto-check.js').then((r) => r.text()).then((t) => { autoTemplate = t; refreshGenerated(); })
+    .catch(() => { $('gen-status').textContent = 'Note: open this page over http(s) (not a local file) so the script can be generated.'; $('gen-status').className = 'status-line warn'; });
 
-  $('reset-btn').addEventListener('click', () => {
-    if (!confirm('Reset preferences, the learned link, and every marked night?')) return;
-    Object.values(STORE).forEach((k) => localStorage.removeItem(k));
-    location.reload();
+  // Re-generate whenever a setting changes.
+  ['start-date', 'end-date', 'guests', 'dow-filter', 'unit-keyword', 'throttle'].forEach((id) =>
+    $(id).addEventListener('change', () => { settings = readSettings(); save(STORE.settings, settings); refreshGenerated(); }));
+  document.querySelectorAll('#length-chips input').forEach((el) =>
+    el.addEventListener('change', () => { settings = readSettings(); save(STORE.settings, settings); refreshGenerated(); }));
+
+  $('copy-script').addEventListener('click', () => {
+    const code = generatedScript();
+    if (!code) { $('gen-status').textContent = 'Script still loading — try again in a second.'; $('gen-status').className = 'status-line warn'; return; }
+    navigator.clipboard.writeText(code).then(() => {
+      $('gen-status').textContent = '✓ Copied. Paste it into the booking page\'s DevTools console and press Enter.';
+      $('gen-status').className = 'status-line ok';
+    });
   });
 
-  $('learn-btn').addEventListener('click', () => {
-    const raw = $('template-url').value.trim();
-    const el = $('template-status');
-    if (!raw) { template = defaultTemplate(); save(STORE.template, template); applyTemplateToUI(); return; }
-    try {
-      template = learnTemplate(raw);
-      save(STORE.template, template);
-      applyTemplateToUI();
-      if (!$('calendar-card').hidden) refresh();
-    } catch (err) {
-      el.textContent = '⚠ ' + err.message;
-      el.className = 'status-line warn';
-    }
+  // Bookmarklet is for dragging, not clicking from here.
+  $('bookmarklet').addEventListener('click', (e) => {
+    e.preventDefault();
+    $('gen-status').textContent = 'Drag this button to your bookmarks bar, then click it while on the booking page (don\'t click it here).';
+    $('gen-status').className = 'status-line warn';
   });
 
-  // Calendar clicks (delegated).
+  $('open-booking').href = BOOKING_BASE;
+
+  // ----- manual fallback -----
+  $('build-btn').addEventListener('click', () => {
+    const s = readSettings();
+    if (dateFromISO(s.end) <= dateFromISO(s.start)) { alert('Latest check-out must be after earliest check-in.'); return; }
+    settings = s; save(STORE.settings, settings);
+    $('manual-body').hidden = false; refreshManual();
+  });
   $('calendar').addEventListener('click', (e) => {
-    const cell = e.target.closest('.day[data-iso]');
-    if (!cell) return;
-    cycleNight(cell.dataset.iso);
-    cell.className = 'day ' + nightState(cell.dataset.iso);
-    renderResults();
+    const cell = e.target.closest('.day[data-iso]'); if (!cell) return;
+    cycleNight(cell.dataset.iso); cell.className = 'day ' + nightState(cell.dataset.iso); renderResults();
   });
-
-  $('rest-free-btn').addEventListener('click', () => {
-    for (const d of nightList()) { const iso = toISO(d); if (!nights[iso]) nights[iso] = 'free'; }
-    save(STORE.nights, nights);
-    refresh();
-  });
-
-  $('all-unknown-btn').addEventListener('click', () => {
-    if (!confirm('Clear every night mark?')) return;
-    nights = {};
-    save(STORE.nights, nights);
-    refresh();
-  });
-
-  $('show-partial').addEventListener('change', renderResults);
-  $('copy-btn').addEventListener('click', copyList);
-  $('print-btn').addEventListener('click', () => window.print());
-
-  // If the user had a calendar going, restore it on load.
-  if (Object.keys(nights).length > 0) {
-    $('calendar-card').hidden = false;
-    $('results-card').hidden = false;
-    refresh();
-  }
+  $('rest-free-btn').addEventListener('click', () => { for (const d of nightList()) { const iso = toISO(d); if (!nights[iso]) nights[iso] = 'free'; } save(STORE.nights, nights); refreshManual(); });
+  $('all-unknown-btn').addEventListener('click', () => { if (!confirm('Clear all night marks?')) return; nights = {}; save(STORE.nights, nights); refreshManual(); });
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/seashore-cottage-finder/styles.css
+++ b/seashore-cottage-finder/styles.css
@@ -1,0 +1,300 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+:root {
+    --primary-color: #0b6e7a;
+    --primary-dark: #084e57;
+    --secondary-color: #f4a259;
+    --accent-color: #e76f51;
+    --success-color: #2a9d8f;
+    --warning-color: #e9c46a;
+    --danger-color: #d1495b;
+    --bg-color: #eef5f6;
+    --card-bg: #ffffff;
+    --text-color: #20323a;
+    --text-muted: #5d7079;
+    --border-color: #d6e3e6;
+    --shadow: 0 2px 10px rgba(11, 110, 122, 0.08);
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    background: linear-gradient(180deg, #dceef0 0%, var(--bg-color) 240px);
+    color: var(--text-color);
+    line-height: 1.6;
+    min-height: 100vh;
+}
+
+.container {
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+header {
+    text-align: center;
+    padding: 36px 16px 16px;
+}
+
+h1 {
+    font-size: 2.3rem;
+    color: var(--primary-dark);
+    margin-bottom: 8px;
+}
+
+.subtitle {
+    font-size: 1.05rem;
+    color: var(--text-muted);
+    max-width: 680px;
+    margin: 0 auto;
+}
+
+.callout {
+    background: #fff8ee;
+    border: 1px solid #f0dcc0;
+    border-left: 4px solid var(--secondary-color);
+    border-radius: 10px;
+    padding: 18px 20px;
+    margin-bottom: 24px;
+    font-size: 0.97rem;
+}
+
+.callout details { margin-top: 10px; }
+.callout summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--primary-dark);
+}
+.callout details p { margin-top: 8px; color: var(--text-muted); }
+
+.card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 24px;
+    margin-bottom: 22px;
+    box-shadow: var(--shadow);
+}
+
+h2 {
+    font-size: 1.3rem;
+    color: var(--primary-dark);
+    margin-bottom: 16px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.step {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    background: var(--primary-color);
+    color: #fff;
+    border-radius: 50%;
+    font-size: 0.9rem;
+    flex: none;
+}
+
+.optional {
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--text-muted);
+    background: #eef5f6;
+    padding: 2px 10px;
+    border-radius: 12px;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 16px;
+    margin-bottom: 18px;
+}
+
+.field { margin-bottom: 18px; }
+.field label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 6px;
+    font-size: 0.92rem;
+}
+
+input[type="date"],
+input[type="number"],
+input[type="text"],
+select,
+textarea {
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    font-size: 0.95rem;
+    font-family: inherit;
+    background: #fff;
+    color: var(--text-color);
+}
+
+textarea { resize: vertical; }
+
+input:focus, select:focus, textarea:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(11, 110, 122, 0.12);
+}
+
+.hint {
+    font-size: 0.82rem;
+    color: var(--text-muted);
+    margin-top: 6px;
+}
+
+.chips { display: flex; flex-wrap: wrap; gap: 10px; }
+.chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 14px;
+    border: 1px solid var(--border-color);
+    border-radius: 20px;
+    cursor: pointer;
+    font-weight: 600;
+    user-select: none;
+}
+.chip input { accent-color: var(--primary-color); }
+
+.actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+    margin-top: 6px;
+}
+.live-actions { margin: 14px 0 4px; }
+
+.btn {
+    padding: 11px 20px;
+    border: none;
+    border-radius: 8px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    text-decoration: none;
+    display: inline-block;
+    transition: transform 0.1s, filter 0.15s;
+}
+.btn:hover { filter: brightness(1.05); }
+.btn:active { transform: translateY(1px); }
+
+.btn-primary { background: var(--primary-color); color: #fff; }
+.btn-secondary { background: var(--secondary-color); color: #3a2a12; }
+.btn-ghost {
+    background: #fff;
+    color: var(--primary-dark);
+    border: 1px solid var(--border-color);
+}
+
+.status-line {
+    margin-top: 12px;
+    font-size: 0.9rem;
+    min-height: 1.2em;
+}
+.status-line.ok { color: var(--success-color); font-weight: 600; }
+.status-line.warn { color: var(--accent-color); font-weight: 600; }
+
+.results-head {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+.results-head h2 { margin-bottom: 0; }
+.results-tools {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    flex-wrap: wrap;
+}
+.inline { display: inline-flex; align-items: center; gap: 6px; font-size: 0.88rem; }
+.mini { width: auto; padding: 6px 10px; font-size: 0.85rem; }
+
+.summary-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 8px;
+}
+.pill {
+    padding: 6px 14px;
+    border-radius: 20px;
+    font-size: 0.85rem;
+    font-weight: 700;
+    background: #eef5f6;
+    color: var(--primary-dark);
+}
+.pill.open { background: #e0f3ef; color: var(--success-color); }
+.pill.full { background: #fbe4e8; color: var(--danger-color); }
+
+.table-wrap { overflow-x: auto; }
+table { width: 100%; border-collapse: collapse; font-size: 0.92rem; }
+th, td {
+    padding: 10px 12px;
+    text-align: left;
+    border-bottom: 1px solid var(--border-color);
+    white-space: nowrap;
+}
+th {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+}
+tbody tr:hover { background: #f7fbfb; }
+
+td .note-input {
+    min-width: 160px;
+    padding: 6px 8px;
+    font-size: 0.85rem;
+}
+td select { padding: 6px 8px; font-size: 0.85rem; }
+td .open-link {
+    color: var(--primary-color);
+    font-weight: 600;
+    text-decoration: none;
+}
+td .open-link:hover { text-decoration: underline; }
+
+tr[data-status="open"] { background: #f1faf8; }
+tr[data-status="full"] { opacity: 0.6; }
+
+.live-cell { font-size: 0.8rem; color: var(--text-muted); }
+
+footer {
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 0.82rem;
+    padding: 24px 16px 40px;
+}
+
+@media print {
+    .callout, .actions, .live-actions, .results-tools,
+    .btn, #live-status, header .subtitle, footer, .field .hint,
+    section.card:nth-of-type(1), section.card:nth-of-type(2),
+    .card details { display: none !important; }
+    body { background: #fff; }
+    .card { box-shadow: none; border: none; }
+    tr[data-status="full"] { opacity: 1; }
+}
+
+@media (max-width: 600px) {
+    h1 { font-size: 1.8rem; }
+    .card { padding: 18px; }
+}

--- a/seashore-cottage-finder/styles.css
+++ b/seashore-cottage-finder/styles.css
@@ -226,6 +226,93 @@ input:focus, select:focus, textarea:focus {
 .inline { display: inline-flex; align-items: center; gap: 6px; font-size: 0.88rem; }
 .mini { width: auto; padding: 6px 10px; font-size: 0.85rem; }
 
+/* ---- Calendar ---- */
+.legend {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 16px;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    margin: 8px 0 16px;
+}
+.swatch {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    border-radius: 4px;
+    vertical-align: middle;
+    margin-right: 4px;
+    border: 1px solid var(--border-color);
+}
+.swatch.free { background: #d6f1ea; border-color: var(--success-color); }
+.swatch.booked { background: #f6cdd5; border-color: var(--danger-color); }
+.swatch.unknown { background: #fff; }
+
+.calendar {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 20px;
+    margin-top: 18px;
+}
+.month {
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 12px;
+}
+.month-head {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 6px;
+    margin-bottom: 8px;
+}
+.month-head h3 { font-size: 1rem; color: var(--primary-dark); }
+.month-head .open-link { font-size: 0.78rem; }
+
+.dow-row, .days {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 4px;
+}
+.dow-row {
+    margin-bottom: 4px;
+    text-align: center;
+    font-size: 0.7rem;
+    color: var(--text-muted);
+}
+.day {
+    aspect-ratio: 1 / 1;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    background: #fff;
+    font-size: 0.82rem;
+    cursor: pointer;
+    color: var(--text-color);
+    padding: 0;
+    transition: filter 0.1s;
+}
+.day:hover:not(.blank) { filter: brightness(0.95); }
+.day.blank { border: none; background: transparent; cursor: default; }
+.day.free { background: #d6f1ea; border-color: var(--success-color); font-weight: 600; }
+.day.booked { background: #f6cdd5; border-color: var(--danger-color); color: var(--danger-color); }
+
+.tag {
+    padding: 3px 10px;
+    border-radius: 12px;
+    font-size: 0.8rem;
+    font-weight: 700;
+}
+.tag-open { background: #e0f3ef; color: var(--success-color); }
+.tag-partial { background: #fdf3da; color: #b07d18; }
+
+.empty {
+    text-align: center;
+    color: var(--text-muted);
+    padding: 24px;
+}
+
 .summary-bar {
     display: flex;
     flex-wrap: wrap;

--- a/seashore-cottage-finder/styles.css
+++ b/seashore-cottage-finder/styles.css
@@ -226,6 +226,56 @@ input:focus, select:focus, textarea:focus {
 .inline { display: inline-flex; align-items: center; gap: 6px; font-size: 0.88rem; }
 .mini { width: auto; padding: 6px 10px; font-size: 0.85rem; }
 
+/* ---- Automated mode ---- */
+code {
+    background: #eef5f6;
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 0.88em;
+    color: var(--danger-color);
+}
+ol.how { margin: 14px 0 14px 20px; }
+ol.how > li { margin-bottom: 14px; }
+
+.loader-options {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 14px;
+    margin-top: 10px;
+}
+.loader {
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 14px;
+    background: #fbfdfd;
+}
+.loader strong { color: var(--primary-dark); }
+.loader p { font-size: 0.85rem; color: var(--text-muted); margin: 6px 0 10px; }
+
+.bookmarklet {
+    display: inline-block;
+    padding: 10px 16px;
+    background: var(--primary-color);
+    color: #fff;
+    border-radius: 8px;
+    text-decoration: none;
+    font-weight: 700;
+    cursor: grab;
+}
+.bookmarklet:active { cursor: grabbing; }
+
+.advanced { margin-top: 16px; }
+.advanced summary { cursor: pointer; font-weight: 600; color: var(--primary-dark); }
+#script-preview {
+    width: 100%;
+    margin-top: 10px;
+    font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+    font-size: 0.78rem;
+    background: #0f2933;
+    color: #d6f1ea;
+    border-color: #0f2933;
+}
+
 /* ---- Calendar ---- */
 .legend {
     display: flex;


### PR DESCRIPTION
Adds a static, client-side tool that turns the resort's one-date-at-a-time
booking flow into a whole-summer checklist for finding an open Premium
Cottage (2 Bedroom) at Sun Retreats Seashore.

- Generates every candidate stay window across a chosen summer range for
  selected stay lengths and check-in day filters
- "Teach it your booking link": learns the booking URL's date format from a
  pasted example so one-click links land on the right dates
- Per-window status tracking (Open/Full/Maybe) + notes, persisted in
  localStorage; filter to open-only, copy, and print the shortlist
- Experimental best-effort live auto-check with graceful CORS/blocked
  fallback and optional CORS-proxy support
- Wires the project into the GitHub Pages deploy workflow and landing page

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015Say5kRXEEerhETPKsiLXt